### PR TITLE
fix: simplify runner labels in build-iso workflow

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build-iso:
-    runs-on: [self-hosted, Linux, X64]
+    runs-on: self-hosted
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Remove specific OS and architecture constraints from the GitHub Actions job configuration. This simplifies the `runs-on` directive to just `self-hosted`, allowing the workflow to run on any available self-hosted runner regardless of platform or architecture.