### PR TITLE
fix: specify runner labels for self-hosted job

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -33,7 +33,7 @@ env:
 
 jobs:
   build-iso:
-    runs-on: self-hosted
+    runs-on: [self-hosted, Linux, X64]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Update the build-iso workflow to use explicit labels [self-hosted, Linux, X64] instead of just 'self-hosted'. This ensures the job is correctly routed to the appropriate runner group and improves reliability of self-hosted execution.