### PR TITLE
fix: update expat and man-pages package URLs

### DIFF
--- a/config/packages.txt
+++ b/config/packages.txt
@@ -13,7 +13,7 @@ https://mirrors.kernel.org/gnu/dejagnu/dejagnu-1.6.3.tar.gz
 https://mirrors.kernel.org/gnu/diffutils/diffutils-3.11.tar.xz
 https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.47.2/e2fsprogs-1.47.2.tar.gz
 https://sourceware.org/ftp/elfutils/0.192/elfutils-0.192.tar.bz2
-https://prdownloads.sourceforge.net/expat/expat-2.7.5.tar.xz
+https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.xz
 https://prdownloads.sourceforge.net/expect/expect5.45.4.tar.gz
 https://astron.com/pub/file/file-5.46.tar.gz
 https://mirrors.kernel.org/gnu/findutils/findutils-4.10.0.tar.xz
@@ -60,7 +60,7 @@ https://ftp.gnu.org/gnu/grub/grub-2.12.tar.xz
 https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz
 https://mirrors.kernel.org/gnu/make/make-4.4.1.tar.gz
 https://download.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz
-https://www.kernel.org/pub/linux/docs/man-pages/man-pages-7.0.tar.xz
+https://www.kernel.org/pub/linux/docs/man-pages/man-pages-7.10.tar.xz
 https://pypi.org/packages/source/M/MarkupSafe/markupsafe-3.0.2.tar.gz
 https://mirrors.kernel.org/gnu/mpc/mpc-1.3.1.tar.gz
 https://mirrors.kernel.org/gnu/mpfr/mpfr-4.2.1.tar.xz


### PR DESCRIPTION
Update expat to version 2.7.0 sourced from GitHub releases. Bump man-pages documentation to version 7.10.