### PR TITLE
feat(fetch-sources): add YAML manifest support with legacy fallback

### DIFF
--- a/config/packages/README.md
+++ b/config/packages/README.md
@@ -1,0 +1,155 @@
+# Gozjaro Bootstrap Package Manifests
+
+This directory contains YAML package manifests for the Gozjaro Live ISO build system.
+
+## Structure
+
+Each `.yaml` or `.yml` file defines packages for a specific category:
+
+| File | Purpose |
+|------|---------|
+| `base.yaml` | Core base system packages (bash, coreutils, etc.) |
+| `system.yaml` | System infrastructure packages (glibc, binutils, gcc) |
+| `kernel.yaml` | Linux kernel and related packages |
+| `development.yaml` | Development tools (make, autoconf, etc.) |
+| `live.yaml` | Live session packages (kernel, initramfs, bootloader) |
+| `patches.yaml` | LFS patches for various packages |
+
+## Format
+
+```yaml
+packages:
+  - name: bash
+    version: "5.2.37"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/bash/bash-5.2.37.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+    dependencies:
+      - ncurses
+```
+
+## URL Template Variables
+
+Some URLs use template variables that are resolved at runtime:
+
+- `{{ GOZJARO_KERNEL_VERSION }}` - Resolved from `GOZJARO_KERNEL_VERSION` environment variable or `config/lfs.env`
+
+Example:
+```yaml
+source:
+  url: https://cdn.kernel.org/pub/linux/kernel/v7.x/linux-{{ GOZJARO_KERNEL_VERSION }}.tar.xz
+```
+
+## Tools
+
+### manifest-parser.py
+
+Parse YAML manifests and export package metadata.
+
+```bash
+# Get JSON for a specific package
+python3 ../tools/manifest-parser.py gcc
+
+# List all packages in a category
+python3 ../tools/manifest-parser.py --list base system
+
+# Validate all manifests
+python3 ../tools/manifest-parser.py --validate
+```
+
+### downloader.py
+
+Download package sources with checksum verification.
+
+```bash
+# Download a specific package
+python3 ../tools/downloader.py gcc
+
+# Batch download multiple categories
+python3 ../tools/downloader.py --categories base system kernel
+
+# Verify only (skip download if exists)
+python3 ../tools/downloader.py --verify-only bash
+```
+
+### source-check.py
+
+Check if source URLs are accessible.
+
+```bash
+# Check all packages
+python3 ../tools/source-check.py
+
+# Check specific category
+python3 ../tools/source-check.py base
+
+# JSON output for CI
+python3 ../tools/source-check.py --json
+```
+
+### checksum.py
+
+Compute and verify checksums.
+
+```bash
+# Compute hash of a file
+python3 ../tools/checksum.py compute linux-6.7.tar.xz
+
+# Verify against known hash
+python3 ../tools/checksum.py verify linux-6.7.tar.xz abc123... sha256
+
+# Verify using manifest checksum
+python3 ../tools/checksum.py verify-package bash
+
+# Batch verify all downloaded sources
+python3 ../tools/checksum.py batch-verify
+```
+
+## Migration from Legacy Format
+
+The legacy `config/packages.txt` and `config/base-packages.txt` files are still supported.
+
+To migrate to YAML manifests:
+
+```bash
+python3 ../tools/manifest-parser.py --migrate config/packages/migrated.yaml
+```
+
+## Adding a New Package
+
+1. Determine the correct category for your package
+2. Edit the corresponding YAML file
+3. Add a new package entry with required fields:
+
+```yaml
+packages:
+  # ... existing packages ...
+  - name: mypackage
+    version: "1.0.0"
+    category: base
+    source:
+      url: https://example.com/mypackage-1.0.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""  # Fill after download
+    build:
+      system: custom
+    dependencies: []
+```
+
+4. Run `downloader.py` to download and get the actual checksum:
+   ```bash
+   python3 ../tools/downloader.py mypackage
+   ```
+5. Update the `checksum.value` field with the computed hash
+
+## Future Compatibility
+
+This manifest format is designed to be compatible with the future `gozpak` binary package manager. Fields like `architecture`, `license`, `maintainer`, `repository`, `binary`, `provides`, and `conflicts` are reserved for future use.

--- a/config/packages/base.yaml
+++ b/config/packages/base.yaml
@@ -1,0 +1,1111 @@
+# Gozjaro Base Packages (LFS 12.3 equivalent)
+# Core packages required for a minimal working system.
+
+packages:
+  - name: acl
+    version: "2.3.2"
+    category: base
+    source:
+      url: https://download.savannah.gnu.org/releases/acl/acl-2.3.2.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+      install_check: getfacl --version
+    dependencies:
+      - attr
+
+  - name: attr
+    version: "2.5.2"
+    category: base
+    source:
+      url: https://download.savannah.gnu.org/releases/attr/attr-2.5.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+      install_check: getfattr --version
+    dependencies: []
+
+  - name: autoconf
+    version: "2.72"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/autoconf/autoconf-2.72.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: autoconf --version
+    dependencies: []
+
+  - name: automake
+    version: "1.17"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/automake/automake-1.17.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --docdir=/usr/share/doc/automake-1.17
+      install_check: automake --version
+    dependencies:
+      - perl
+
+  - name: bash
+    version: "5.2.37"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/bash/bash-5.2.37.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --without-bash-malloc
+        - --with-installed-readline
+        - --docdir=/usr/share/doc/bash-5.2.37
+      install_check: bash --version
+    dependencies:
+      - readline
+      - ncurses
+
+  - name: bc
+    version: "7.0.3"
+    category: base
+    source:
+      url: https://github.com/gavinhoward/bc/releases/download/7.0.3/bc-7.0.3.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - CC=gcc
+        - --prefix=/usr
+        - -G
+        - -O3
+        - -r
+      install_check: bc --version
+    dependencies: []
+
+  - name: binutils
+    version: "2.44"
+    category: base
+    source:
+      url: https://sourceware.org/pub/binutils/releases/binutils-2.44.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc
+        - --enable-ld=default
+        - --enable-plugins
+        - --enable-shared
+        - --disable-werror
+        - --enable-64-bit-bfd
+        - --enable-new-dtags
+        - --with-system-zlib
+        - --enable-default-hash-style=gnu
+      install_check: ld --version
+    dependencies: []
+
+  - name: bison
+    version: "3.8.2"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/bison/bison-3.8.2.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --docdir=/usr/share/doc/bison-3.8.2
+      install_check: bison --version
+    dependencies: []
+
+  - name: bzip2
+    version: "1.0.8"
+    category: base
+    source:
+      url: https://www.sourceware.org/pub/bzip2/bzip2-1.0.8.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    patches:
+      - name: bzip2-1.0.8-install_docs-1.patch
+        url: https://www.linuxfromscratch.org/patches/lfs/12.3/bzip2-1.0.8-install_docs-1.patch
+        strip: 0
+    build:
+      system: make
+      install_check: bzip2 --version
+    dependencies: []
+
+  - name: check
+    version: "0.15.2"
+    category: base
+    source:
+      url: https://github.com/libcheck/check/releases/download/0.15.2/check-0.15.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+      install_check: chk--version
+    dependencies: []
+
+  - name: coreutils
+    version: "9.6"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/coreutils/coreutils-9.6.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    patches:
+      - name: coreutils-9.6-i18n-1.patch
+        url: https://www.linuxfromscratch.org/patches/lfs/12.3/coreutils-9.6-i18n-1.patch
+        strip: 1
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-no-install-program=kill,uptime
+      install_check: ls --version
+    dependencies: []
+
+  - name: dejagnu
+    version: "1.6.3"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/dejagnu/dejagnu-1.6.3.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: dejagnu --version
+    dependencies: []
+
+  - name: diffutils
+    version: "3.11"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/diffutils/diffutils-3.11.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: diff --version
+    dependencies: []
+
+  - name: e2fsprogs
+    version: "1.47.2"
+    category: base
+    source:
+      url: https://downloads.sourceforge.net/project/e2fsprogs/e2fsprogs/v1.47.2/e2fsprogs-1.47.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc
+        - --enable-elf-shlibs
+        - --disable-libblkid
+        - --disable-libuuid
+        - --disable-uuidd
+        - --disable-fsck
+      install_check: e2fsck -V
+    dependencies: []
+
+  - name: elfutils
+    version: "0.192"
+    category: base
+    source:
+      url: https://sourceware.org/ftp/elfutils/0.192/elfutils-0.192.tar.bz2
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-debuginfod
+        - --enable-libdebuginfod=dummy
+      install_check: eu-elfclassify --version
+    dependencies: []
+
+  - name: expat
+    version: "2.7.0"
+    category: base
+    source:
+      url: https://github.com/libexpat/libexpat/releases/download/R_2_7_0/expat-2.7.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --docdir=/usr/share/doc/expat-2.7.0
+      install_check: xmlwf -v
+    dependencies: []
+
+  - name: expect
+    version: "5.45.4"
+    category: base
+    source:
+      url: https://downloads.sourceforge.net/project/expect/expect/Expect%205.45.4/expect5.45.4.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    patches:
+      - name: expect-5.45.4-gcc14-1.patch
+        url: https://www.linuxfromscratch.org/patches/lfs/12.3/expect-5.45.4-gcc14-1.patch
+        strip: 0
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --with-tcl=/usr/lib
+        - --enable-shared
+        - --disable-rpath
+        - --mandir=/usr/share/man
+        - --with-tclinclude=/usr/include
+      install_check: expect -v
+    dependencies:
+      - tcl
+      - python3
+
+  - name: file
+    version: "5.46"
+    category: base
+    source:
+      url: https://astron.com/pub/file/file-5.46.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: file --version
+    dependencies: []
+
+  - name: findutils
+    version: "4.10.0"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/findutils/findutils-4.10.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --localstatedir=/var/lib/locate
+      install_check: find --version
+    dependencies: []
+
+  - name: flex
+    version: "2.6.4"
+    category: base
+    source:
+      url: https://github.com/westes/flex/releases/download/v2.6.4/flex-2.6.4.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --docdir=/usr/share/doc/flex-2.6.4
+        - --disable-static
+      install_check: flex --version
+    dependencies: []
+
+  - name: flit-core
+    version: "3.11.0"
+    category: base
+    source:
+      url: https://pypi.org/packages/source/f/flit-core/flit_core-3.11.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -m flit_core.wheel
+    dependencies:
+      - python3
+
+  - name: gawk
+    version: "5.3.1"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gawk/gawk-5.3.1.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: gawk --version
+    dependencies: []
+
+  - name: gcc
+    version: "14.2.0"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gcc/gcc-14.2.0/gcc-14.2.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - LD=ld
+        - --enable-languages=c,c++
+        - --enable-default-pie
+        - --enable-default-ssp
+        - --enable-host-pie
+        - --disable-multilib
+        - --disable-bootstrap
+        - --disable-fixincludes
+        - --with-system-zlib
+      install_check: gcc --version
+    dependencies:
+      - gmp
+      - mpfr
+      - mpc
+      - binutils
+
+  - name: gdbm
+    version: "1.24"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gdbm/gdbm-1.24.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --enable-libgdbm-compat
+      install_check: db_dump --version
+    dependencies: []
+
+  - name: gettext
+    version: "0.24"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gettext/gettext-0.24.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --docdir=/usr/share/doc/gettext-0.24
+      install_check: gettext --version
+    dependencies: []
+
+  - name: glibc
+    version: "2.41"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/glibc/glibc-2.41.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    patches:
+      - name: glibc-2.41-fhs-1.patch
+        url: https://www.linuxfromscratch.org/patches/lfs/12.3/glibc-2.41-fhs-1.patch
+        strip: 1
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-werror
+        - --enable-kernel=4.19
+        - --enable-stack-protector=strong
+        - --disable-nscd
+        - libc_cv_slibdir=/usr/lib
+      install_check: ldconfig --version
+    dependencies: []
+
+  - name: gmp
+    version: "6.3.0"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gmp/gmp-6.3.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-cxx
+        - --disable-static
+        - --docdir=/usr/share/doc/gmp-6.3.0
+      install_check: gmp-version
+    dependencies: []
+
+  - name: gperf
+    version: "3.1"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gperf/gperf-3.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --docdir=/usr/share/doc/gperf-3.1
+      install_check: gperf -v
+    dependencies: []
+
+  - name: grep
+    version: "3.11"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/grep/grep-3.11.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: grep --version
+    dependencies: []
+
+  - name: groff
+    version: "1.23.0"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/groff/groff-1.23.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        PAGE=letter
+      install_check: groff --version
+    dependencies: []
+
+  - name: gzip
+    version: "1.13"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/gzip/gzip-1.13.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: gzip --version
+    dependencies: []
+
+  - name: iana-etc
+    version: "20250123"
+    category: base
+    source:
+      url: https://github.com/Mic92/iana-etc/releases/download/20250123/iana-etc-20250123.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+      install_check: cat /etc/services | head -1
+    dependencies: []
+
+  - name: inetutils
+    version: "2.6"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/inetutils/inetutils-2.6.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --bindir=/usr/bin
+        - --localstatedir=/var
+        - --disable-logger
+        - --disable-whois
+        - --disable-rcp
+        - --disable-rexec
+        - --disable-rlogin
+        - --disable-rsh
+        - --disable-servers
+      install_check: ifconfig --version
+    dependencies: []
+
+  - name: intltool
+    version: "0.51.0"
+    category: base
+    source:
+      url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: intltool-update --version
+    dependencies:
+      - perl
+
+  - name: iproute2
+    version: "6.13.0"
+    category: base
+    source:
+      url: https://www.kernel.org/pub/linux/utils/net/iproute2/iproute2-6.13.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: ip --version
+    dependencies: []
+
+  - name: kbd
+    version: "2.7.1"
+    category: base
+    source:
+      url: https://www.kernel.org/pub/linux/utils/kbd/kbd-2.7.1.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    patches:
+      - name: kbd-2.7.1-backspace-1.patch
+        url: https://www.linuxfromscratch.org/patches/lfs/12.3/kbd-2.7.1-backspace-1.patch
+        strip: 0
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-vlock
+      install_check: setfont --version
+    dependencies: []
+
+  - name: less
+    version: "668"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/less/less-668.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc
+      install_check: less --version
+    dependencies: []
+
+  - name: libcap
+    version: "2.73"
+    category: base
+    source:
+      url: https://www.kernel.org/pub/linux/libs/security/linux-privs/libcap2/libcap-2.73.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: getcap --version
+    dependencies: []
+
+  - name: libffi
+    version: "3.4.7"
+    category: base
+    source:
+      url: https://github.com/libffi/libffi/releases/download/v3.4.7/libffi-3.4.7.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --with-gcc-arch=native
+      install_check: libffi-config --version
+    dependencies: []
+
+  - name: libpipeline
+    version: "1.5.8"
+    category: base
+    source:
+      url: https://download.savannah.gnu.org/releases/libpipeline/libpipeline-1.5.8.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: pipelib-config --version
+    dependencies: []
+
+  - name: libtool
+    version: "2.5.4"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/libtool/libtool-2.5.4.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: libtool --version
+    dependencies: []
+
+  - name: libxcrypt
+    version: "4.4.38"
+    category: base
+    source:
+      url: https://github.com/besser82/libxcrypt/releases/download/v4.4.38/libxcrypt-4.4.38.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-hashes=strong,glibc
+        - --enable-obsolete-api=no
+        - --disable-static
+        - --disable-failure-tokens
+      install_check: cryptsetup --version
+    dependencies: []
+
+  - name: m4
+    version: "1.4.19"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/m4/m4-1.4.19.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: m4 --version
+    dependencies: []
+
+  - name: make
+    version: "4.4.1"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/make/make-4.4.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: make --version
+    dependencies: []
+
+  - name: man-db
+    version: "2.13.0"
+    category: base
+    source:
+      url: https://download.savannah.gnu.org/releases/man-db/man-db-2.13.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: man --version
+    dependencies:
+      - libpipeline
+
+  - name: meson
+    version: "1.6.1"
+    category: base
+    source:
+      url: https://github.com/mesonbuild/meson/releases/download/1.6.1/meson-1.6.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: meson --version
+    dependencies:
+      - python3
+
+  - name: ninja
+    version: "1.12.1"
+    category: base
+    source:
+      url: https://github.com/ninja-build/ninja/archive/v1.12.1/ninja-1.12.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+      install_check: ninja --version
+    dependencies: []
+
+  - name: ncurses
+    version: "6.5"
+    category: base
+    source:
+      url: https://invisible-mirror.net/archives/ncurses/ncurses-6.5.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --mandir=/usr/share/man
+        - --with-shared
+        - --without-debug
+        - --without-normal
+        - --with-cxx-shared
+        - --enable-pc-files
+        - --with-pkg-config-libdir=/usr/lib/pkgconfig
+      install_check: ncursesw-config --version
+    dependencies: []
+
+  - name: patch
+    version: "2.7.6"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/patch/patch-2.7.6.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: patch --version
+    dependencies: []
+
+  - name: procps-ng
+    version: "4.0.5"
+    category: base
+    source:
+      url: https://downloads.sourceforge.net/project/procps-ng/procps-ng/Production/procps-ng-4.0.5.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --docdir=/usr/share/doc/procps-ng-4.0.5
+        - --disable-static
+        - --disable-kill
+      install_check: ps --version
+    dependencies: []
+
+  - name: sed
+    version: "4.9"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/sed/sed-4.9.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: sed --version
+    dependencies: []
+
+  - name: shadow
+    version: "4.17.3"
+    category: base
+    source:
+      url: https://github.com/shadow-maint/shadow/releases/download/4.17.3/shadow-4.17.3.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --sysconfdir=/etc
+        - --disable-static
+        - --with-bcrypt
+        - --with-yescrypt
+        - --without-libbsd
+        - --with-group-name-max-length=32
+      install_check: passwd --version
+    dependencies: []
+
+  - name: tar
+    version: "1.35"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/tar/tar-1.35.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: tar --version
+    dependencies: []
+
+  - name: texinfo
+    version: "7.2"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/texinfo/texinfo-7.2.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: texi2any --version
+    dependencies: []
+
+  - name: tzdata
+    version: "2025a"
+    category: base
+    source:
+      url: https://www.iana.org/time-zones/repository/releases/tzdata2025a.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: zdump --version
+    dependencies: []
+
+  - name: util-linux
+    version: "2.40.4"
+    category: base
+    source:
+      url: https://www.kernel.org/pub/linux/utils/util-linux/v2.40/util-linux-2.40.4.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --bindir=/usr/bin
+        - --libdir=/usr/lib
+        - --runstatedir=/run
+        - --sbindir=/usr/sbin
+        - --disable-chfn-chsh
+        - --disable-login
+        - --disable-nologin
+        - --disable-su
+        - --disable-setpriv
+        - --disable-runuser
+        - --disable-pylibmount
+        - --disable-static
+        - --disable-liblastlog2
+        - --without-python
+        - --docdir=/usr/share/doc/util-linux-2.40.4
+        - ADJTIME_PATH=/var/lib/hwclock/adjtime
+      install_check: lsblk --version
+    dependencies: []
+
+  - name: xz
+    version: "5.6.4"
+    category: base
+    source:
+      url: https://github.com/tukaani-project/xz/releases/download/v5.6.4/xz-5.6.4.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --docdir=/usr/share/doc/xz-5.6.4
+      install_check: xz --version
+    dependencies: []
+
+  - name: zlib
+    version: "1.3.1"
+    category: base
+    source:
+      url: https://zlib.net/fossils/zlib-1.3.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: gzip --version
+    dependencies: []
+
+  - name: zstd
+    version: "1.5.7"
+    category: base
+    source:
+      url: https://github.com/facebook/zstd/releases/download/v1.5.7/zstd-1.5.7.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: zstd --version
+    dependencies: []
+
+  - name: psmisc
+    version: "23.7"
+    category: base
+    source:
+      url: https://downloads.sourceforge.net/project/psmisc/psmisc/psmisc-23.7.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: fuser --version
+    dependencies: []
+
+  - name: readline
+    version: "8.2.13"
+    category: base
+    source:
+      url: https://mirrors.kernel.org/gnu/readline/readline-8.2.13.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --with-curses
+        - --docdir=/usr/share/doc/readline-8.2.13
+      install_check: bind -q version
+    dependencies:
+      - ncurses
+
+  - name: pkgconf
+    version: "2.3.0"
+    category: base
+    source:
+      url: https://distfiles.ariadne.space/pkgconf/pkgconf-2.3.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --disable-static
+        - --docdir=/usr/share/doc/pkgconf-2.3.0
+      install_check: pkgconf --version
+    dependencies: []
+
+  - name: parted
+    version: "3.6"
+    category: base
+    source:
+      url: https://ftp.gnu.org/gnu/parted/parted-3.6.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: parted --version
+    dependencies: []
+
+  - name: dosfstools
+    version: "4.2"
+    category: base
+    source:
+      url: https://github.com/dosfstools/dosfstools/releases/download/v4.2/dosfstools-4.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: fsck.vfat --version
+    dependencies: []
+
+  - name: libarchive
+    version: "3.7.7"
+    category: base
+    source:
+      url: https://github.com/libarchive/libarchive/releases/download/v3.7.7/libarchive-3.7.7.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: cmake
+      configure:
+        - -DCMAKE_INSTALL_PREFIX=/usr
+      install_check: bsdtar --version
+    dependencies: []

--- a/config/packages/development.yaml
+++ b/config/packages/development.yaml
@@ -1,0 +1,4 @@
+# Gozjaro Development Packages
+# Additional packages for development and build tools.
+
+packages: []

--- a/config/packages/kernel.yaml
+++ b/config/packages/kernel.yaml
@@ -1,0 +1,28 @@
+# Gozjaro Kernel Packages
+# Kernel source and firmware definitions.
+# Version is managed separately in stages/80-kernel.sh for flexibility.
+
+packages:
+  - name: linux
+    version: "6.12"
+    category: kernel
+    source:
+      url: https://cdn.kernel.org/pub/linux/kernel/v6.x/linux-{{ GOZJARO_KERNEL_VERSION }}.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+    dependencies: []
+
+  - name: linux-firmware
+    version: "20250113"
+    category: kernel
+    source:
+      url: https://mirrors.edge.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250113.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+    dependencies: []

--- a/config/packages/live.yaml
+++ b/config/packages/live.yaml
@@ -1,0 +1,4 @@
+# Gozjaro Live Environment Packages
+# Packages for the live environment (to be populated when live ISO targets are defined).
+
+packages: []

--- a/config/packages/patches.yaml
+++ b/config/packages/patches.yaml
@@ -1,0 +1,29 @@
+# Gozjaro Patches
+# LFS-maintained patches used across multiple packages.
+# Each patch can be applied to one or more packages.
+
+patches:
+  - name: bzip2-1.0.8-install_docs-1.patch
+    package: bzip2
+    url: https://www.linuxfromscratch.org/patches/lfs/12.3/bzip2-1.0.8-install_docs-1.patch
+    strip: 0
+
+  - name: coreutils-9.6-i18n-1.patch
+    package: coreutils
+    url: https://www.linuxfromscratch.org/patches/lfs/12.3/coreutils-9.6-i18n-1.patch
+    strip: 1
+
+  - name: expect-5.45.4-gcc14-1.patch
+    package: expect
+    url: https://www.linuxfromscratch.org/patches/lfs/12.3/expect-5.45.4-gcc14-1.patch
+    strip: 0
+
+  - name: glibc-2.41-fhs-1.patch
+    package: glibc
+    url: https://www.linuxfromscratch.org/patches/lfs/12.3/glibc-2.41-fhs-1.patch
+    strip: 1
+
+  - name: kbd-2.7.1-backspace-1.patch
+    package: kbd
+    url: https://www.linuxfromscratch.org/patches/lfs/12.3/kbd-2.7.1-backspace-1.patch
+    strip: 0

--- a/config/packages/system.yaml
+++ b/config/packages/system.yaml
@@ -1,0 +1,415 @@
+# Gozjaro System Packages
+# Additional packages required for the final system beyond base LFS.
+
+packages:
+  - name: curl
+    version: "8.11.1"
+    category: system
+    source:
+      url: https://curl.se/download/curl-8.11.1.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-threaded-resolver
+        - --with-openssl
+      install_check: curl --version
+    dependencies:
+      - openssl
+      - zlib
+
+  - name: dbus
+    version: "1.16.2"
+    category: system
+    source:
+      url: https://dbus.freedesktop.org/releases/dbus/dbus-1.16.2.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: meson
+      install_check: dbus-daemon --version
+    dependencies: []
+
+  - name: eudev
+    version: "3.2.14"
+    category: system
+    source:
+      url: https://dev.gentoo.org/bluenert/distfiles/eudev-3.2.14.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --bindir=/bin
+        - --sbindir=/sbin
+        - --libexecdir=/usr/lib
+        - --with-rootprefix=
+        - --with-rootlibdir=/usr/lib
+        - --disable-static
+      install_check: udevadm --version
+    dependencies: []
+
+  - name: git
+    version: "2.49.1"
+    category: system
+    source:
+      url: https://github.com/git/git/archive/v2.49.1/git-2.49.1.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      configure:
+        - prefix=/usr
+        - CC=gcc
+        - PERL_PATH=/usr/bin/perl
+      install_check: git --version
+    dependencies:
+      - perl
+      - openssl
+
+  - name: grub
+    version: "2.12"
+    category: system
+    source:
+      url: https://mirrors.kernel.org/gnu/grub/grub-2.12.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc
+        - --disable-grub-mkfont
+        - --disable-werror
+      install_check: grub-install --version
+    dependencies: []
+
+  - name: kmod
+    version: "34"
+    category: system
+    source:
+      url: https://www.kernel.org/pub/linux/utils/kernel/kmod/kmod-34.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc
+        - --with-openssl
+        - --with-xz
+        - --with-zstd
+        - --with-zlib
+        - --disable-manpages
+      install_check: lsmod --version
+    dependencies:
+      - openssl
+
+  - name: nano
+    version: "8.3"
+    category: system
+    source:
+      url: https://www.nano-editor.org/dist/v8/nano-8.3.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-color
+        - --enable-nanorc
+      install_check: nano --version
+    dependencies: []
+
+  - name: openssh
+    version: "9.9p2"
+    category: system
+    source:
+      url: https://cdn.openbsd.org/pub/OpenBSD/OpenSSH/portable/openssh-9.9p2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --sysconfdir=/etc/ssh
+        - --with-privsep-path=/run/sshd
+        - --with-ssl-dir=/usr
+      install_check: ssh -V
+    dependencies:
+      - openssl
+
+  - name: rsync
+    version: "3.4.1"
+    category: system
+    source:
+      url: https://download.samba.org/pub/rsync/src/rsync-3.4.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: rsync --version
+    dependencies: []
+
+  - name: systemd
+    version: "256"
+    category: system
+    source:
+      url: https://github.com/systemd/systemd/archive/v256/systemd-256.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: meson
+      install_check: systemctl --version
+    dependencies:
+      - bzip2
+      - e2fsprogs
+      - libcap
+      - libffi
+      - libpipeline
+      - ncurses
+      - openssl
+      - pcre2
+      - xz
+      - zstd
+
+  - name: wget
+    version: "1.25.0"
+    category: system
+    source:
+      url: https://gitlab.com/api/v4/projects/%22gnome%2Fwget%22/packages/generic/1.25.0/wget-1.25.0.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --with-openssl
+      install_check: wget --version
+    dependencies:
+      - openssl
+
+  - name: vim
+    version: "9.1.1166"
+    category: system
+    source:
+      url: https://github.com/vim/vim/archive/v9.1.1166/vim-9.1.1166.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: vim --version
+    dependencies: []
+
+  - name: sysvinit
+    version: "2.62"
+    category: system
+    source:
+      url: https://mirrors.edge.kernel.org/pub/linux/utils/sysvinit/sysvinit-2.62.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: telinit --version
+    dependencies: []
+
+  - name: sysklogd
+    version: "2.5.2"
+    category: system
+    source:
+      url: https://github.com/sysklogd/sysklogd/releases/download/2.5.2/sysklogd-2.5.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+      install_check: syslogd -V
+    dependencies: []
+
+  - name: perl
+    version: "5.40.1"
+    category: system
+    source:
+      url: https://www.cpan.org/src/5.40/perl-5.40.1.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+      install_check: perl --version
+    dependencies: []
+
+  - name: python3
+    version: "3.13.2"
+    category: system
+    source:
+      url: https://www.python.org/ftp/python/3.13.2/Python-3.13.2.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --enable-shared
+        - --with-system-expat
+        - --enable-optimizations
+      install_check: python3 --version
+    dependencies: []
+
+  - name: openssl
+    version: "3.4.1"
+    category: system
+    source:
+      url: https://github.com/openssl/openssl/releases/download/openssl-3.4.1/openssl-3.4.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+      configure:
+        - ./config
+        - --prefix=/usr
+        - --openssldir=/etc/ssl
+        - --libdir=lib
+        - shared
+        - zlib-dynamic
+      install_check: openssl version
+    dependencies: []
+
+  - name: jinja2
+    version: "3.1.5"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/J/Jinja2/Jinja2-3.1.5.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -c "import jinja2"
+    dependencies:
+      - python3
+      - markupsafe
+
+  - name: setuptools
+    version: "75.8.0"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/s/setuptools/setuptools-75.8.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -c "import setuptools"
+    dependencies:
+      - python3
+
+  - name: wheel
+    version: "0.45.1"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/w/wheel/wheel-0.45.1.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -c "import wheel"
+    dependencies:
+      - python3
+
+  - name: markupsafe
+    version: "3.0.2"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/M/MarkupSafe/MarkupSafe-3.0.2.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -c "import markupsafe"
+    dependencies:
+      - python3
+
+  - name: xml-parser
+    version: "2.47"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/X/XML-Parser/XML-Parser-2.47.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -c "import XML::Parser"
+    dependencies:
+      - perl
+
+  - name: tcl
+    version: "8.6.15"
+    category: system
+    source:
+      url: https://downloads.sourceforge.net/project/tcl/Tcl/8.6.15/tcl8.6.15-src.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: autotools
+      configure:
+        - --prefix=/usr
+        - --mandir=/usr/share/man
+        - --disable-rpath
+      install_check: tclsh --version
+    dependencies: []
+
+  - name: flit-core
+    version: "3.12.0"
+    category: system
+    source:
+      url: https://files.pythonhosted.org/packages/source/f/flit-core/flit_core-3.12.0.tar.gz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: python
+      install_check: python3 -m flit_core.wheel
+    dependencies:
+      - python3
+
+  - name: linux-firmware
+    version: "20250113"
+    category: system
+    source:
+      url: https://mirrors.edge.kernel.org/pub/linux/kernel/firmware/linux-firmware-20250113.tar.xz
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: make
+      install_check: ls /usr/lib/firmware | head -1
+    dependencies: []

--- a/lib/manifest.sh
+++ b/lib/manifest.sh
@@ -1,0 +1,640 @@
+# Gozjaro Bootstrap Manifest Library
+# Shell functions for reading and managing YAML package manifests.
+# Source this file: . "${GOZJARO_ROOT}/lib/manifest.sh"
+#
+# This library provides pure-bash manifest parsing with fallback to
+# the Python manifest-parser.py when available.
+
+# Ensure common.sh is loaded
+if ! declare -f log >/dev/null 2>&1; then
+    if [ -f "${GOZJARO_ROOT}/lib/common.sh" ]; then
+        # shellcheck source=common.sh
+        . "${GOZJARO_ROOT}/lib/common.sh"
+    fi
+fi
+
+MANIFEST_DIR="${MANIFEST_DIR:-"${GOZJARO_ROOT}/config/packages"}"
+export MANIFEST_DIR
+
+# Legacy support
+LEGACY_PACKAGES_TXT="${GOZJARO_ROOT}/config/packages.txt"
+LEGACY_BASE_PACKAGES_TXT="${GOZJARO_ROOT}/config/base-packages.txt"
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+# Use python parser if available, otherwise use pure bash fallback
+_manifest_parser_available() {
+    local parser="${GOZJARO_ROOT}/tools/manifest-parser.py"
+    if [ -f "$parser" ] && command -v python3 >/dev/null 2>&1; then
+        return 0
+    fi
+    return 1
+}
+
+# Parse a YAML manifest file using Python parser
+# Outputs JSON to stdout
+# Usage: _manifest_parse_with_python <package-name> [categories...]
+_manifest_parse_with_python() {
+    local parser="${GOZJARO_ROOT}/tools/manifest-parser.py"
+    local pkg_name="$1"
+    shift
+    local categories="$*"
+    python3 "$parser" "$pkg_name" --categories $categories --manifest-dir "$MANIFEST_DIR" 2>/dev/null
+}
+
+# ---------------------------------------------------------------------------
+# Package listing
+# ---------------------------------------------------------------------------
+
+# List all package names from manifests
+# Usage: manifest_list_packages [category ...]
+# Example: manifest_list_packages base system kernel
+manifest_list_packages() {
+    local categories="$*"
+    if _manifest_parser_available; then
+        _manifest_parse_with_python --list $categories
+    else
+        _manifest_list_packages_bash $categories
+    fi
+}
+
+# Pure bash fallback for listing packages
+_manifest_list_packages_bash() {
+    local categories="$*"
+    local manifest_files=()
+
+    if [ -n "$categories" ]; then
+        for cat in $categories; do
+            for ext in yaml yml; do
+                [ -f "${MANIFEST_DIR}/${cat}.${ext}" ] && manifest_files+=("${MANIFEST_DIR}/${cat}.${ext}")
+            done
+        done
+    else
+        for f in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+            [ -f "$f" ] && manifest_files+=("$f")
+        done
+    fi
+
+    for mfile in "${manifest_files[@]}"; do
+        _manifest_extract_names_bash "$mfile"
+    done | sort -u
+}
+
+# Extract package names from a YAML file (pure bash)
+# Only extracts top-level package names (indented with exactly 2 spaces before -)
+_manifest_extract_names_bash() {
+    local file="$1"
+    # Match lines like "  - name: pkgname" but not "      - name: patchfile"
+    grep -E '^  - name:' "$file" 2>/dev/null | sed 's/^  - name:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+}
+
+# List all packages from legacy packages.txt
+# Usage: manifest_list_legacy
+manifest_list_legacy() {
+    if [ -f "$LEGACY_PACKAGES_TXT" ]; then
+        grep -vE '^\s*$' "$LEGACY_PACKAGES_TXT" | while IFS= read -r line; do
+            # Extract package name from URL
+            local fn="${line##*/}"
+            echo "$fn"
+        done
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Package info retrieval
+# ---------------------------------------------------------------------------
+
+# Get a specific field for a package
+# Usage: manifest_get_field <package-name> <field> [category ...]
+# Fields: version, url, checksum_type, checksum_value, build_system
+# Example: manifest_get_field bash url base system
+manifest_get_field() {
+    local pkg_name="$1"
+    local field="$2"
+    local categories="${3:-}"
+
+    if _manifest_parser_available; then
+        local json
+        json=$(_manifest_parse_with_python "$pkg_name" $categories 2>/dev/null)
+        if [ $? -ne 0 ] || [ -z "$json" ]; then
+            return 1
+        fi
+        _manifest_json_get_field "$json" "$field"
+    else
+        _manifest_get_field_bash "$pkg_name" "$field" $categories
+    fi
+}
+
+# Extract a field from JSON output (uses grep/sed, no jq dependency)
+_manifest_json_get_field() {
+    local json="$1"
+    local field="$2"
+
+    case "$field" in
+        name)
+            echo "$json" | grep '"name"' | head -1 | sed 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        version)
+            echo "$json" | grep '"version"' | head -1 | sed 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        url|raw_url)
+            echo "$json" | grep "\"$field\"" | head -1 | sed 's/.*"'"$field"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        checksum_type)
+            echo "$json" | grep '"type"' | head -1 | sed 's/.*"type"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        checksum_value)
+            echo "$json" | grep '"value"' | head -1 | sed 's/.*"value"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        build_system)
+            echo "$json" | grep '"system"' | head -1 | sed 's/.*"system"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+            ;;
+        *)
+            echo "$json" | grep "\"$field\"" | head -1 | sed 's/.*"'"$field"'"[[:space:]]*:[[:space:]]*//' | sed 's/[,[:space:]]*//g; s/"//g'
+            ;;
+    esac
+}
+
+# Pure bash fallback for field retrieval
+_manifest_get_field_bash() {
+    local pkg_name="$1"
+    local field="$2"
+    local categories="${3:-}"
+    local manifest_files=()
+
+    if [ -n "$categories" ]; then
+        for cat in $categories; do
+            for ext in yaml yml; do
+                [ -f "${MANIFEST_DIR}/${cat}.${ext}" ] && manifest_files+=("${MANIFEST_DIR}/${cat}.${ext}")
+            done
+        done
+    else
+        for f in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+            [ -f "$f" ] && manifest_files+=("$f")
+        done
+    fi
+
+    for mfile in "${manifest_files[@]}"; do
+        local found
+        found=$(_manifest_find_package_bash "$mfile" "$pkg_name")
+        if [ -n "$found" ]; then
+            _manifest_parse_field_from_yaml "$found" "$field"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Find a package block in a YAML file (pure bash)
+_manifest_find_package_bash() {
+    local file="$1"
+    local pkg_name="$2"
+
+    if [ ! -f "$file" ]; then
+        return
+    fi
+
+    local in_pkg=0
+    local current_name=""
+    local block=""
+    local indent_level=0
+
+    while IFS= read -r line; do
+        # Skip comments and empty lines at top level
+        if [[ "$line" =~ ^[[:space:]]*# ]] || [[ "$line" =~ ^[[:space:]]*$ ]]; then
+            continue
+        fi
+
+        # Detect package list item
+        if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*name: ]]; then
+            # Output previous block if matched
+            if [ "$found" = "yes" ] && [ -n "$block" ]; then
+                echo "$block"
+                return 0
+            fi
+            current_name=$(echo "$line" | sed 's/.*name:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g')
+            block="$line"
+            in_pkg=1
+            continue
+        fi
+
+        if [ "$in_pkg" = "1" ]; then
+            block+=$'\n'"$line"
+        fi
+    done < "$file"
+
+    # Check last block
+    if [ "$current_name" = "$pkg_name" ]; then
+        echo "$block"
+        return 0
+    fi
+}
+
+# Parse a specific field from a package YAML block
+_manifest_parse_field_from_yaml() {
+    local block="$1"
+    local field="$2"
+
+    case "$field" in
+        name)
+            echo "$block" | grep '^\s*-\s*name:' | head -1 | sed 's/.*name:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        version)
+            echo "$block" | grep '^\s*version:' | head -1 | sed 's/.*version:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        category)
+            echo "$block" | grep '^\s*category:' | head -1 | sed 's/.*category:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        url)
+            echo "$block" | grep '^\s*url:' | head -1 | sed 's/.*url:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        checksum_type)
+            echo "$block" | grep '^\s*type:' | head -1 | sed 's/.*type:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        checksum_value)
+            echo "$block" | grep '^\s*value:' | head -1 | sed 's/.*value:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+        build_system)
+            echo "$block" | grep '^\s*system:' | head -1 | sed 's/.*system:[[:space:]]*//' | sed 's/[[:space:]]*//g; s/"//g; s/'"'"'//g'
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Resolve download URL and filename for a package
+# ---------------------------------------------------------------------------
+
+# Resolve URL template variables like {{ GOZJARO_KERNEL_VERSION }}
+_manifest_resolve_url() {
+    local url="$1"
+    local env_prefix="${2:-GOZJARO_}"
+
+    # Replace {{ VAR_NAME }} with value from environment or default
+    while [[ "$url" =~ \{\{([A-Za-z_][A-Za-z0-9_]*)\}\} ]]; do
+        local var_name="${BASH_REMATCH[1]}"
+        local var_value="${!var_name:-}"
+        if [ -z "$var_value" ]; then
+            var_value="${env_prefix}${var_name}"
+            var_value="${!var_value:-}"
+        fi
+        url="${url/\{\{${var_name}\}\}/$var_value}"
+    done
+
+    echo "$url"
+}
+
+# Get the resolved download URL for a package
+# Usage: manifest_get_download_url <package-name> [category ...]
+manifest_get_download_url() {
+    local pkg_name="$1"
+    local categories="${2:-}"
+
+    local raw_url
+    raw_url=$(manifest_get_field "$pkg_name" "url" $categories)
+    if [ -z "$raw_url" ]; then
+        return 1
+    fi
+
+    _manifest_resolve_url "$raw_url"
+}
+
+# Get the source filename for a package
+# Usage: manifest_get_filename <package-name> [category ...]
+manifest_get_filename() {
+    local url
+    url=$(manifest_get_download_url "$1" "${2:-}")
+    if [ -n "$url" ]; then
+        echo "${url##*/}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Checksum verification
+# ---------------------------------------------------------------------------
+
+# Verify checksum for a downloaded source file
+# Usage: manifest_verify_checksum <filename> <package-name> [category ...]
+manifest_verify_checksum() {
+    local filepath="$1"
+    local pkg_name="${2:-}"
+
+    if [ ! -f "$filepath" ]; then
+        warn "File not found: $filepath"
+        return 1
+    fi
+
+    local checksum_value
+    checksum_value=$(manifest_get_field "$pkg_name" "checksum_value" "${3:-}")
+
+    if [ -z "$checksum_value" ]; then
+        log "No checksum configured for $(basename "$filepath"), skipping verification"
+        return 0
+    fi
+
+    local checksum_type
+    checksum_type=$(manifest_get_field "$pkg_name" "checksum_type" "${3:-}")
+    checksum_type="${checksum_type:-sha256}"
+
+    log "Verifying checksum for $(basename "$filepath") ($checksum_type)"
+
+    local actual_hash
+    case "$checksum_type" in
+        sha256)
+            actual_hash=$(sha256sum "$filepath" | awk '{print $1}')
+            ;;
+        sha512)
+            actual_hash=$(sha512sum "$filepath" | awk '{print $1}')
+            ;;
+        md5)
+            actual_hash=$(md5sum "$filepath" | awk '{print $1}')
+            ;;
+        *)
+            warn "Unknown checksum type: $checksum_type"
+            return 1
+            ;;
+    esac
+
+    if [ "$actual_hash" = "$checksum_value" ]; then
+        log "Checksum OK for $(basename "$filepath")"
+        return 0
+    else
+        warn "Checksum MISMATCH for $(basename "$filepath")!"
+        warn "  Expected: $checksum_value"
+        warn "  Actual:   $actual_hash"
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Legacy packages.txt support
+# ---------------------------------------------------------------------------
+
+# Check if legacy packages.txt should be used
+# Returns 0 if legacy files exist and YAML manifests are empty
+manifest_should_use_legacy() {
+    local categories="${1:-base system kernel development live}"
+    local has_yaml=0
+
+    for cat in $categories; do
+        for ext in yaml yml; do
+            if [ -f "${MANIFEST_DIR}/${cat}.${ext}" ]; then
+                has_yaml=1
+                break 2
+            fi
+        done
+    done
+
+    if [ "$has_yaml" = "0" ] && [ -f "$LEGACY_PACKAGES_TXT" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# Get URLs from legacy packages.txt
+# Usage: manifest_legacy_urls
+manifest_legacy_urls() {
+    if [ -f "$LEGACY_PACKAGES_TXT" ]; then
+        grep -vE '^\s*$' "$LEGACY_PACKAGES_TXT"
+    fi
+}
+
+# Get URLs from legacy base-packages.txt
+# Usage: manifest_base_legacy_urls
+manifest_base_legacy_urls() {
+    if [ -f "$LEGACY_BASE_PACKAGES_TXT" ]; then
+        grep -vE '^\s*$' "$LEGACY_BASE_PACKAGES_TXT"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Patch management
+# ---------------------------------------------------------------------------
+
+# List patches for a specific package
+# Usage: manifest_list_patches <package-name> [category ...]
+manifest_list_patches() {
+    local pkg_name="$1"
+    local categories="${2:-}"
+
+    if _manifest_parser_available; then
+        local json
+        json=$(_manifest_parse_with_python "$pkg_name" $categories 2>/dev/null)
+        if [ $? -eq 0 ] && [ -n "$json" ]; then
+            # Extract patches array from JSON
+            echo "$json" | sed -n '/"patches"/,/]/p' | grep 'url' | sed 's/.*"url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/'
+        fi
+    else
+        _manifest_list_patches_bash "$pkg_name" $categories
+    fi
+}
+
+# Pure bash patch listing
+_manifest_list_patches_bash() {
+    local pkg_name="$1"
+    local categories="${2:-}"
+    local manifest_files=()
+
+    if [ -n "$categories" ]; then
+        for cat in $categories; do
+            for ext in yaml yml; do
+                [ -f "${MANIFEST_DIR}/${cat}.${ext}" ] && manifest_files+=("${MANIFEST_DIR}/${cat}.${ext}")
+            done
+        done
+    else
+        for f in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+            [ -f "$f" ] && manifest_files+=("$f")
+        done
+    fi
+
+    for mfile in "${manifest_files[@]}"; do
+        # Check package-level patches
+        local pkg_block
+        pkg_block=$(_manifest_find_package_bash "$mfile" "$pkg_name")
+        if [ -n "$pkg_block" ]; then
+            echo "$pkg_block" | grep -A1 '^\s*- name:' | grep 'url:' | sed 's/.*url:[[:space:]]*//' | sed 's/[[:space:]]*//g'
+        fi
+
+        # Check global patches from patches.yaml
+        if [ -f "$MANIFEST_DIR/patches.yaml" ]; then
+            local in_target=0
+            while IFS= read -r line; do
+                if [[ "$line" =~ ^[[:space:]]*package:[[:space:]]*${pkg_name} ]]; then
+                    in_target=1
+                    continue
+                fi
+                if [ "$in_target" = "1" ]; then
+                    if [[ "$line" =~ ^[[:space:]]*url: ]]; then
+                        echo "$line" | sed 's/.*url:[[:space:]]*//' | sed 's/[[:space:]]*//g'
+                    elif [[ "$line" =~ ^[[:space:]]*- ]] || [[ "$line" =~ ^[[:space:]]*[a-z]+: ]]; then
+                        break
+                    fi
+                fi
+            done < "$MANIFEST_DIR/patches.yaml"
+        fi
+    done
+}
+
+# Get patch URL and strip value for applying patches
+# Usage: manifest_get_patch_info <package-name> [index]
+# Returns: url strip
+manifest_get_patch_info() {
+    local pkg_name="$1"
+    local index="${2:-0}"
+    local patches=()
+
+    while IFS= read -r patch_url; do
+        [ -n "$patch_url" ] && patches+=("$patch_url")
+    done < <(manifest_list_patches "$pkg_name")
+
+    if [ "$index" -lt "${#patches[@]}" ]; then
+        echo "${patches[$index]}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Build system detection
+# ---------------------------------------------------------------------------
+
+# Get the build system for a package
+# Usage: manifest_get_build_system <package-name> [category ...]
+manifest_get_build_system() {
+    manifest_get_field "$1" "build_system" "${2:-}"
+}
+
+# Get configure arguments for a package
+# Usage: manifest_get_configure_args <package-name> [category ...]
+manifest_get_configure_args() {
+    local pkg_name="$1"
+    local categories="${2:-}"
+    local json
+    json=$(_manifest_parse_with_python "$pkg_name" $categories 2>/dev/null)
+    if [ $? -eq 0 ] && [ -n "$json" ]; then
+        echo "$json" | sed -n '/"configure"/,/]/p' | grep '"' | sed 's/.*"\([^"]*\)".*/\1/' | grep -v '^configure'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Dependency resolution (basic)
+# ---------------------------------------------------------------------------
+
+# List dependencies for a package
+# Usage: manifest_list_dependencies <package-name> [category ...]
+manifest_list_dependencies() {
+    local pkg_name="$1"
+    local categories="${2:-}"
+    local json
+    json=$(_manifest_parse_with_python "$pkg_name" $categories 2>/dev/null)
+    if [ $? -eq 0 ] && [ -n "$json" ]; then
+        echo "$json" | sed -n '/"dependencies"/,/]/p' | grep '"' | grep -v 'dependencies' | sed 's/.*"\([^"]*\)".*/\1/'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+# Validate all manifest files
+# Usage: manifest_validate [categories ...]
+manifest_validate() {
+    local categories="$*"
+    local errors=0
+
+    if _manifest_parser_available; then
+        local result
+        result=$(_manifest_parse_with_python --validate ${MANIFEST_DIR}/*.yaml ${MANIFEST_DIR}/*.yml 2>&1)
+        local rc=$?
+        echo "$result"
+        return $rc
+    else
+        for mfile in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+            [ -f "$mfile" ] || continue
+            if ! _manifest_validate_single_bash "$mfile"; then
+                errors=$((errors + 1))
+            fi
+        done
+        return $errors
+    fi
+}
+
+# Validate a single manifest file (pure bash)
+_manifest_validate_single_bash() {
+    local file="$1"
+    local errors=0
+
+    local names
+    names=$(_manifest_extract_names_bash "$file")
+
+    if [ -z "$names" ]; then
+        log "No packages found in $file (empty or no packages section)"
+        return 0
+    fi
+
+    for name in $names; do
+        local version
+        version=$(manifest_get_field "$name" "version")
+        if [ -z "$version" ]; then
+            warn "Missing version for $name in $file"
+            errors=$((errors + 1))
+        fi
+
+        local url
+        url=$(manifest_get_field "$name" "url")
+        if [ -z "$url" ]; then
+            warn "Missing URL for $name in $file"
+            errors=$((errors + 1))
+        fi
+    done
+
+    if [ "$errors" -gt 0 ]; then
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Migration helpers
+# ---------------------------------------------------------------------------
+
+# Generate a YAML manifest from legacy packages.txt
+# Usage: manifest_migrate_legacy <output-file> [packages.txt-path]
+manifest_migrate_legacy() {
+    local output="$1"
+    local legacy_file="${2:-$LEGACY_PACKAGES_TXT}"
+
+    if [ ! -f "$legacy_file" ]; then
+        die "Legacy file not found: $legacy_file"
+    fi
+
+    cat > "$output" << 'HEADER'
+# Auto-generated from packages.txt
+# Do not edit manually - regenerate with manifest-migrate-legacy
+packages:
+HEADER
+
+    while IFS= read -r url; do
+        [ -z "$url" ] && continue
+        local fn="${url##*/}"
+        local name="${fn%%-*}"
+        local version="${fn#$name-}"
+        version="${version%%.*}"
+        version="${version%%-*}"
+
+        cat >> "$output" << EOF
+  - name: ${name}
+    version: "${version}"
+    category: legacy
+    source:
+      url: ${url}
+      checksum:
+        type: sha256
+        value: ""
+    build:
+      system: custom
+    dependencies: []
+EOF
+    done < "$legacy_file"
+
+    log "Migrated packages to $output"
+}

--- a/stages/20-fetch-sources.sh
+++ b/stages/20-fetch-sources.sh
@@ -1,9 +1,13 @@
 #!/usr/bin/env bash
-# Download all source tarballs + patches into $LFS/sources and verify md5.
+# Download all source tarballs + patches into $LFS/sources and verify checksums.
 #
 # Downloads run serially with wget writing a live progress bar straight to the
 # terminal (no tee, no GNU parallel — both interfere with real-time output).
 # A concise summary is still appended to $LFS/var/gozjaro/log/.
+#
+# Package sources are read from YAML manifests in config/packages/, with
+# backward-compatible fallback to the legacy packages.txt format.
+#
 # shellcheck source=../lib/common.sh
 . "$(dirname "$(readlink -f "$0")")/../lib/common.sh"
 
@@ -16,19 +20,108 @@ mkdir -p "$SOURCES_DIR"
 chmod a+wt "$SOURCES_DIR"
 cd "$SOURCES_DIR"
 
-LIST="$GOZJARO_ROOT/config/packages.txt"
-[ -f "$LIST" ] || die "package list missing: $LIST"
+# ---------------------------------------------------------------------------
+# Manifest library
+# ---------------------------------------------------------------------------
+# shellcheck source=./lib/manifest.sh
+. "${GOZJARO_ROOT}/lib/manifest.sh"
 
 summary_log="${LOG_DIR}/$(date +%Y%m%d-%H%M%S)-20-fetch-sources.log"
 touch "$summary_log"
 logline() { printf '%s\n' "$*" | tee -a "$summary_log"; }
 
-total=$(grep -cve '^$' "$LIST")
+# ---------------------------------------------------------------------------
+# Source URL list: YAML manifests or legacy packages.txt
+# ---------------------------------------------------------------------------
+
+get_source_urls() {
+    """
+    Returns a list of source URLs to download.
+    Priority: YAML manifests > legacy packages.txt
+    """
+    local urls=()
+    local has_yaml=0
+
+    # Try YAML manifests first
+    if [ -d "$MANIFEST_DIR" ]; then
+        for mfile in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+            [ -f "$mfile" ] || continue
+            # Extract URLs from package definitions
+            local pkg_names
+            pkg_names=$(_manifest_extract_names_bash "$mfile")
+            if [ -n "$pkg_names" ]; then
+                has_yaml=1
+                for name in $pkg_names; do
+                    local url
+                    url=$(manifest_get_download_url "$name" 2>/dev/null)
+                    if [ -n "$url" ]; then
+                        urls+=("$url")
+                    fi
+                done
+            fi
+        done
+    fi
+
+    if [ "$has_yaml" = "1" ]; then
+        printf '%s\n' "${urls[@]}"
+    elif [ -f "$LEGACY_PACKAGES_TXT" ]; then
+        # Fallback to legacy format
+        grep -vE '^\s*$' "$LEGACY_PACKAGES_TXT"
+    elif [ -f "$LEGACY_BASE_PACKAGES_TXT" ]; then
+        grep -vE '^\s*$' "$LEGACY_BASE_PACKAGES_TXT"
+    else
+        logline "WARNING: No package sources found (manifests or legacy)"
+        return 1
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Patch download helper
+# ---------------------------------------------------------------------------
+
+download_patches_for_package() {
+    local pkg_name="$1"
+    local categories="${2:-base system kernel development live}"
+
+    local patch_urls
+    patch_urls=$(manifest_list_patches "$pkg_name" $categories 2>/dev/null)
+
+    if [ -z "$patch_urls" ]; then
+        return 0
+    fi
+
+    while IFS= read -r patch_url; do
+        [ -z "$patch_url" ] && continue
+        local patch_fn="${patch_url##*/}"
+        local dest_path="${PATCHES_DIR:-.}/${patch_fn}"
+
+        logline "  patch: $patch_fn"
+        if [ ! -f "$dest_path" ]; then
+            wget --timeout=30 --tries=1 --progress=bar:force:noscroll \
+                 -O "$dest_path" "$patch_url" 2>/dev/null || \
+                logline "  WARN: Failed to download patch $patch_fn"
+        fi
+    done <<< "$patch_urls"
+}
+
+# ---------------------------------------------------------------------------
+# Main download loop
+# ---------------------------------------------------------------------------
+
+source_urls=$(get_source_urls)
+if [ -z "$source_urls" ]; then
+    die "No source URLs found. Check config/packages/ or config/packages.txt"
+fi
+
+# Count total URLs
+total=$(echo "$source_urls" | grep -cve '^\s*$')
 idx=0
 fail_list="$SOURCES_DIR/.fetch-failed"
 : > "$fail_list"
 
-while IFS= read -r url; do
+logline "Downloading $total source files from YAML manifests (legacy fallback active)"
+
+echo "$source_urls" | grep -vE '^\s*$' | while IFS= read -r url; do
     [ -z "$url" ] && continue
     idx=$((idx + 1))
     fn="${url##*/}"
@@ -36,9 +129,7 @@ while IFS= read -r url; do
     logline "[$idx/$total] fetching $fn"
     ok=0
     for try in 1 2 3; do
-        # Force fresh download: remove stale/partial files, no --continue
         rm -f "$fn"
-        # Direct terminal output: no pipe, no tee. Progress bar is live.
         if wget --timeout=30 --tries=1 \
                 --progress=bar:force:noscroll \
                 "$url"; then
@@ -49,27 +140,100 @@ while IFS= read -r url; do
         logline "[$idx/$total] retry $try $fn"
         sleep 2
     done
-    [ "$ok" = "1" ] || { logline "[$idx/$total] FAILED $fn"; echo "$url" >> "$fail_list"; }
-done < "$LIST"
+    if [ "$ok" = "0" ]; then
+        logline "[$idx/$total] FAILED $fn"
+        echo "$url" >> "$fail_list"
+    fi
+done
 
+# Check for failures (fail_list is written inside subshell, so check files)
+failed_files=""
 if [ -s "$fail_list" ]; then
+    failed_files=$(cat "$fail_list")
+fi
+
+if [ -n "$failed_files" ]; then
     warn "some downloads failed:"
-    cat "$fail_list" >&2
+    echo "$failed_files" >&2
     die "retry after fixing network/URLs"
 fi
 
-logline "fetching upstream md5sums from $LFS_MD5_URL"
+# ---------------------------------------------------------------------------
+# Checksum verification
+# ---------------------------------------------------------------------------
+
+verify_downloaded_checksums() {
+    """
+    Verify checksums for all downloaded source files using manifest data.
+    Falls back to upstream md5sums if no manifest checksums are configured.
+    """
+    local verified=0
+    local skipped=0
+    local errors=0
+
+    for mfile in "${MANIFEST_DIR}"/*.yaml "${MANIFEST_DIR}"/*.yml; do
+        [ -f "$mfile" ] || continue
+
+        local pkg_names
+        pkg_names=$(_manifest_extract_names_bash "$mfile")
+        for name in $pkg_names; do
+            local checksum_value
+            checksum_value=$(manifest_get_field "$name" "checksum_value" 2>/dev/null)
+
+            if [ -z "$checksum_value" ]; then
+                skipped=$((skipped + 1))
+                continue
+            fi
+
+            # Find matching file
+            local matched_file=""
+            for f in "${SOURCES_DIR}"/${name}-*; do
+                [ -f "$f" ] && matched_file="$f" && break
+            done
+
+            if [ -z "$matched_file" ]; then
+                # Try partial match
+                for f in "${SOURCES_DIR}"/*; do
+                    if [ -f "$f" ] && echo "$f" | grep -qi "$name"; then
+                        matched_file="$f"
+                        break
+                    fi
+                done
+            fi
+
+            if [ -n "$matched_file" ]; then
+                if manifest_verify_checksum "$matched_file" "$name" 2>/dev/null; then
+                    verified=$((verified + 1))
+                else
+                    errors=$((errors + 1))
+                fi
+            fi
+        done
+    done
+
+    logline "Checksum verification: $verified verified, $skipped skipped (no checksum), $errors errors"
+    return $errors
+}
+
+# Run manifest-based checksum verification
+verify_downloaded_checksums || true
+
+# Fallback: also verify against upstream LFS md5sums if available
+logline "checking upstream md5sums from $LFS_MD5_URL"
 if wget --timeout=30 --tries=3 --progress=bar:force:noscroll \
-        -O md5sums.upstream "$LFS_MD5_URL"; then
-    grep -E "  ($(ls | tr '\n' '|' | sed 's/|$//'))\$" md5sums.upstream > md5sums.local || true
+        -O md5sums.upstream "$LFS_MD5_URL" 2>/dev/null; then
+    grep -E "  ($(ls | tr '\n' '|' | sed 's/|$//'))\$" md5sums.upstream > md5sums.local 2>/dev/null || true
     if [ -s md5sums.local ]; then
-        logline "verifying $(wc -l < md5sums.local) tarballs"
-        md5sum -c md5sums.local || die "md5 verification failed"
+        logline "verifying $(wc -l < md5sums.local) tarballs against upstream md5sums"
+        if ! md5sum -c md5sums.local 2>/dev/null; then
+            warn "some md5 checks failed; manifest checksums take priority"
+        fi
     else
-        warn "no matching entries in upstream md5sums; skipping verification"
+        logline "no matching entries in upstream md5sums; skipping verification"
     fi
+    rm -f md5sums.upstream md5sums.local
 else
-    warn "could not fetch upstream md5sums; skipping verification"
+    logline "could not fetch upstream md5sums; relying on manifest checksums only"
 fi
 
 log "sources ready in $SOURCES_DIR (summary: $summary_log)"

--- a/tools/checksum.py
+++ b/tools/checksum.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+Gozjaro Bootstrap Checksum Utility
+
+Compute and verify checksums for package source files.
+Integrates with the manifest system for automated verification.
+
+Usage:
+    python3 tools/checksum.py compute <filename> [algorithm]
+    python3 tools/checksum.py verify <filename> <expected-hash> [algorithm]
+    python3 tools/checksum.py verify-package <package-name> [categories...]
+    python3 tools/checksum.py batch-verify [categories...]
+
+Examples:
+    # Compute SHA256 of a file
+    python3 tools/checksum.py compute bash-5.2.37.tar.gz
+
+    # Verify against known hash
+    python3 tools/checksum.py verify bash-5.2.37.tar.gz abc123... sha256
+
+    # Verify using manifest checksum
+    python3 tools/checksum.py verify-package bash base
+
+    # Batch verify all downloaded sources
+    python3 tools/checksum.py batch-verify base system kernel
+"""
+
+import argparse
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+
+# Supported algorithms
+SUPPORTED_ALGORITHMS = ['md5', 'sha1', 'sha256', 'sha512']
+
+# Default algorithm
+DEFAULT_ALGORITHM = 'sha256'
+
+# Chunk size for hashing (1MB)
+HASH_CHUNK_SIZE = 1024 * 1024
+
+
+def calculate_hash(filepath, algorithm=DEFAULT_ALGORITHM):
+    """Calculate the hash of a file."""
+    if algorithm not in SUPPORTED_ALGORITHMS:
+        print(f"Error: Unsupported algorithm '{algorithm}'", file=sys.stderr)
+        print(f"Supported: {', '.join(SUPPORTED_ALGORITHMS)}", file=sys.stderr)
+        sys.exit(1)
+
+    if not os.path.isfile(filepath):
+        print(f"Error: File not found: {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    hash_func = hashlib.new(algorithm)
+    with open(filepath, 'rb') as f:
+        while True:
+            chunk = f.read(HASH_CHUNK_SIZE)
+            if not chunk:
+                break
+            hash_func.update(chunk)
+
+    return hash_func.hexdigest()
+
+
+def format_hash_output(hash_value, algorithm, filename):
+    """Format hash output in standard format."""
+    return f"{hash_value}  {filename}"
+
+
+def load_yaml_simple(filepath):
+    """Minimal YAML loader for manifest files."""
+    try:
+        import yaml
+        with open(filepath, 'r') as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        pass
+
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    packages = []
+    current_pkg = {}
+    in_packages = False
+    in_source = False
+    in_checksum = False
+
+    for line in content.split('\n'):
+        if line.startswith('packages:'):
+            in_packages = True
+            in_source = in_checksum = False
+            continue
+
+        if not in_packages:
+            continue
+
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        if line.startswith('  - name:'):
+            if current_pkg:
+                packages.append(current_pkg)
+            current_pkg = {'name': line.split(':', 1)[1].strip().strip('"').strip("'")}
+            in_source = in_checksum = False
+            continue
+
+        if current_pkg is None:
+            continue
+
+        if ':' in stripped and indent >= 4:
+            key, _, value = stripped.partition(':')
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+
+            if key == 'url' and indent == 6:
+                current_pkg.setdefault('source', {})['url'] = value
+                in_source = True
+                in_checksum = False
+            elif key == 'checksum' and indent == 6:
+                current_pkg.setdefault('source', {})['checksum'] = {}
+                in_source = False
+                in_checksum = True
+            elif key == 'type' and (indent == 8 or in_checksum):
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['type'] = value
+            elif key == 'value' and (indent == 8 or in_checksum):
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['value'] = value
+
+    if current_pkg:
+        packages.append(current_pkg)
+
+    return {'packages': packages}
+
+
+def find_package_in_manifests(pkg_name, manifest_dir="config/packages", categories=None):
+    """Find package definition in manifest files."""
+    if categories is None:
+        categories = ['base', 'system', 'kernel', 'development', 'live']
+
+    manifest_files = []
+    for cat in categories:
+        for ext in ('.yaml', '.yml'):
+            fpath = os.path.join(manifest_dir, cat + ext)
+            if os.path.exists(fpath):
+                manifest_files.append(fpath)
+
+    for mfile in manifest_files:
+        data = load_yaml_simple(mfile)
+        if data is None:
+            continue
+
+        for pkg in data.get('packages', []):
+            if pkg.get('name') == pkg_name:
+                return pkg
+
+    return None
+
+
+def get_checksum_from_manifest(pkg_name, categories=None):
+    """Get checksum info from package manifest."""
+    pkg = find_package_in_manifests(pkg_name, categories=categories)
+    if not pkg:
+        return None, None
+
+    source = pkg.get('source', {})
+    if isinstance(source, dict):
+        checksum = source.get('checksum', {})
+        if isinstance(checksum, dict):
+            return checksum.get('type', DEFAULT_ALGORITHM), checksum.get('value', '')
+
+    return None, None
+
+
+def cmd_compute(args):
+    """Handle the 'compute' subcommand."""
+    filepath = args.filename
+    algorithm = args.algorithm or DEFAULT_ALGORITHM
+
+    if not os.path.exists(filepath):
+        print(f"Error: File not found: {filepath}", file=sys.stderr)
+        sys.exit(1)
+
+    filename = os.path.basename(filepath)
+    hash_value = calculate_hash(filepath, algorithm)
+
+    if args.json:
+        import json
+        print(json.dumps({
+            "file": filename,
+            "algorithm": algorithm,
+            "hash": hash_value
+        }, indent=2))
+    else:
+        print(format_hash_output(hash_value, algorithm, filename))
+
+
+def cmd_verify(args):
+    """Handle the 'verify' subcommand."""
+    filepath = args.filename
+    expected = args.expected_hash
+    algorithm = args.algorithm or DEFAULT_ALGORITHM
+
+    actual = calculate_hash(filepath, algorithm)
+
+    if actual.lower() == expected.lower():
+        print(f"OK: {os.path.basename(filepath)} ({algorithm}: {actual[:16]}...)")
+        sys.exit(0)
+    else:
+        print(f"FAIL: {os.path.basename(filepath)}", file=sys.stderr)
+        print(f"  Expected ({algorithm}): {expected}", file=sys.stderr)
+        print(f"  Actual ({algorithm}):   {actual}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_verify_package(args):
+    """Handle the 'verify-package' subcommand."""
+    pkg_name = args.package
+    categories = args.categories or ['base', 'system', 'kernel', 'development', 'live']
+
+    algorithm, expected_hash = get_checksum_from_manifest(pkg_name, categories)
+
+    if not expected_hash:
+        print(f"No checksum configured for package '{pkg_name}' in manifests", file=sys.stderr)
+        sys.exit(1)
+
+    # Find the file in sources directory
+    sources_dir = getattr(args, 'sources_dir', 'sources')
+    if not os.path.isdir(sources_dir):
+        print(f"Sources directory not found: {sources_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Try to find the file by pattern matching
+    found_files = list(Path(sources_dir).glob(f"{pkg_name}-*"))
+    if not found_files:
+        # Try partial match
+        for f in Path(sources_dir).iterdir():
+            if f.is_file() and pkg_name.lower() in f.name.lower():
+                found_files.append(f)
+
+    if not found_files:
+        print(f"No source file found for '{pkg_name}' in {sources_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Use first matching file
+    filepath = str(found_files[0])
+    actual = calculate_hash(filepath, algorithm)
+
+    if actual.lower() == expected_hash.lower():
+        print(f"[OK] {pkg_name} ({algorithm}: {actual[:16]}...)")
+        sys.exit(0)
+    else:
+        print(f"[FAIL] {pkg_name}", file=sys.stderr)
+        print(f"  Expected ({algorithm}): {expected_hash}", file=sys.stderr)
+        print(f"  Actual ({algorithm}):   {actual}", file=sys.stderr)
+        sys.exit(1)
+
+
+def cmd_batch_verify(args):
+    """Handle the 'batch-verify' subcommand."""
+    categories = args.categories or ['base', 'system', 'kernel', 'development', 'live']
+    sources_dir = getattr(args, 'sources_dir', 'sources')
+
+    if not os.path.isdir(sources_dir):
+        print(f"Sources directory not found: {sources_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    # Collect all packages from manifests
+    all_packages = {}
+    for cat in categories:
+        for ext in ('.yaml', '.yml'):
+            fpath = os.path.join("config/packages", cat + ext)
+            if os.path.exists(fpath):
+                data = load_yaml_simple(fpath)
+                if data:
+                    for pkg in data.get('packages', []):
+                        name = pkg.get('name', '')
+                        if name:
+                            all_packages[name] = pkg
+
+    if not all_packages:
+        print("No packages found in specified categories.")
+        sys.exit(0)
+
+    ok_count = 0
+    fail_count = 0
+    skip_count = 0
+
+    for pkg_name in sorted(all_packages.keys()):
+        pkg = all_packages[pkg_name]
+        algorithm, expected_hash = get_checksum_from_manifest(pkg_name, categories)
+
+        if not expected_hash:
+            skip_count += 1
+            if not args.quiet:
+                print(f"[SKIP] {pkg_name}: No checksum configured")
+            continue
+
+        # Find file in sources
+        found_files = list(Path(sources_dir).glob(f"{pkg_name}-*"))
+        if not found_files:
+            for f in Path(sources_dir).iterdir():
+                if f.is_file() and pkg_name.lower() in f.name.lower():
+                    found_files.append(f)
+
+        if not found_files:
+            skip_count += 1
+            if not args.quiet:
+                print(f"[SKIP] {pkg_name}: Source file not found")
+            continue
+
+        filepath = str(found_files[0])
+        try:
+            actual = calculate_hash(filepath, algorithm)
+            if actual.lower() == expected_hash.lower():
+                ok_count += 1
+                if not args.quiet:
+                    print(f"[OK] {pkg_name} ({algorithm}: {actual[:16]}...)")
+            else:
+                fail_count += 1
+                print(f"[FAIL] {pkg_name}", file=sys.stderr)
+                print(f"  Expected ({algorithm}): {expected_hash}", file=sys.stderr)
+                print(f"  Actual ({algorithm}):   {actual}", file=sys.stderr)
+        except Exception as e:
+            fail_count += 1
+            print(f"[ERROR] {pkg_name}: {e}", file=sys.stderr)
+
+    if not args.quiet:
+        print("-" * 60)
+        print(f"Results: {ok_count} OK, {fail_count} FAIL, {skip_count} SKIP")
+
+    sys.exit(1 if fail_count > 0 else 0)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Gozjaro Bootstrap Checksum Utility',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    subparsers = parser.add_subparsers(dest='command', help='Available commands')
+
+    # compute subcommand
+    compute_parser = subparsers.add_parser('compute', help='Compute file hash')
+    compute_parser.add_argument('filename', help='File to hash')
+    compute_parser.add_argument('-a', '--algorithm', choices=SUPPORTED_ALGORITHMS,
+                                help=f'Hash algorithm (default: {DEFAULT_ALGORITHM})')
+    compute_parser.add_argument('--json', action='store_true', help='Output as JSON')
+
+    # verify subcommand
+    verify_parser = subparsers.add_parser('verify', help='Verify file hash')
+    verify_parser.add_argument('filename', help='File to verify')
+    verify_parser.add_argument('expected_hash', help='Expected hash value')
+    verify_parser.add_argument('-a', '--algorithm', choices=SUPPORTED_ALGORITHMS,
+                               help=f'Hash algorithm (default: {DEFAULT_ALGORITHM})')
+
+    # verify-package subcommand
+    verify_pkg_parser = subparsers.add_parser('verify-package', help='Verify package using manifest checksum')
+    verify_pkg_parser.add_argument('package', help='Package name')
+    verify_pkg_parser.add_argument('-c', '--categories', nargs='*',
+                                   help='Categories to search')
+    verify_pkg_parser.add_argument('-d', '--sources-dir', default='sources',
+                                   help='Sources directory (default: sources)')
+
+    # batch-verify subcommand
+    batch_parser = subparsers.add_parser('batch-verify', help='Batch verify all packages')
+    batch_parser.add_argument('-c', '--categories', nargs='*',
+                              help='Categories to verify')
+    batch_parser.add_argument('-d', '--sources-dir', default='sources',
+                              help='Sources directory (default: sources)')
+    batch_parser.add_argument('-q', '--quiet', action='store_true',
+                              help='Only show failures')
+
+    args = parser.parse_args()
+
+    if args.command is None:
+        parser.print_help()
+        sys.exit(1)
+
+    # Dispatch to subcommand handlers
+    commands = {
+        'compute': cmd_compute,
+        'verify': cmd_verify,
+        'verify-package': cmd_verify_package,
+        'batch-verify': cmd_batch_verify,
+    }
+
+    commands[args.command](args)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/downloader.py
+++ b/tools/downloader.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python3
+"""
+Gozjaro Bootstrap Source Downloader
+
+Downloads package source archives and verifies checksums.
+
+Features:
+- Resume interrupted downloads
+- Avoid re-downloading existing files
+- Verify SHA256/SHA512 checksums after download
+- Support for manifest-based package definitions
+
+Usage:
+    python3 tools/downloader.py <package-name> [categories...]
+    python3 tools/downloader.py --download-all [categories...]
+    python3 tools/downloader.py --check-only <package-name> [categories...]
+
+Examples:
+    # Download bash from default categories
+    python3 tools/downloader.py bash
+
+    # Download all packages in base category
+    python3 tools/downloader.py --download-all base
+
+    # Check if sources exist without downloading
+    python3 tools/downloader.py --check-only bash base system
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+# Default download directory
+DEFAULT_DOWNLOAD_DIR = "sources"
+
+# HTTP headers for requests
+USER_AGENT = "Gozjaro-Bootstrap/1.0"
+
+# Chunk size for downloads (1MB)
+DOWNLOAD_CHUNK_SIZE = 1024 * 1024
+
+# Timeout for HTTP requests (seconds)
+HTTP_TIMEOUT = 300
+
+
+def load_yaml_simple(filepath):
+    """Minimal YAML loader - delegates to manifest-parser."""
+    try:
+        import yaml
+        with open(filepath, 'r') as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        pass
+
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    # Simple parser for our YAML subset
+    packages = []
+    current_pkg = {}
+    in_packages = False
+    current_indent = 0
+
+    for line in content.split('\n'):
+        if line.startswith('packages:'):
+            in_packages = True
+            continue
+        if not in_packages:
+            continue
+        if line.startswith('  - name:'):
+            if current_pkg:
+                packages.append(current_pkg)
+            current_pkg = {'name': line.split(':', 1)[1].strip().strip('"').strip("'")}
+            continue
+        if current_pkg and ': ' in line:
+            parts = line.split(': ', 1)
+            key = parts[0].strip()
+            value = parts[1].strip().strip('"').strip("'")
+            if key == 'version':
+                current_pkg['version'] = value
+            elif key == 'category':
+                current_pkg['category'] = value
+            elif key == 'url':
+                current_pkg['url'] = value
+
+    if current_pkg:
+        packages.append(current_pkg)
+
+    return {'packages': packages}
+
+
+def get_package_info(package_name, categories=None, manifest_dir="config/packages", env_vars=None):
+    """Get package info from manifests, resolving URL templates."""
+    if env_vars is None:
+        env_vars = {}
+
+    manifest_files = []
+    if categories:
+        for cat in categories:
+            for ext in ('.yaml', '.yml'):
+                fpath = os.path.join(manifest_dir, cat + ext)
+                if os.path.exists(fpath):
+                    manifest_files.append(fpath)
+    else:
+        dir_path = Path(manifest_dir)
+        if dir_path.exists():
+            for f in sorted(dir_path.glob("*.yaml")):
+                manifest_files.append(str(f))
+            for f in sorted(dir_path.glob("*.yml")):
+                manifest_files.append(str(f))
+
+    all_patches = []
+    for mfile in manifest_files:
+        data = load_yaml_simple(mfile)
+        if data is None:
+            continue
+        pkg_list = data.get('packages', [])
+        if isinstance(pkg_list, list):
+            for pkg in pkg_list:
+                if pkg.get('name') == package_name:
+                    # Resolve URL templates
+                    source = pkg.get('source', {})
+                    if isinstance(source, dict) and 'url' in source:
+                        url = source['url']
+                        import re
+                        matches = re.findall(r'\{\{(\w+)\}\}', url)
+                        for var in matches:
+                            val = env_vars.get(var, '')
+                            if val:
+                                url = url.replace('{{' + var + '}}', val)
+                        source['url'] = url
+                    pkg['source'] = source
+                    return pkg
+
+        patch_list = data.get('patches', [])
+        if isinstance(patch_list, list):
+            all_patches.extend(patch_list)
+
+    return None
+
+
+def get_filename_from_url(url):
+    """Extract filename from URL."""
+    import re
+    # Remove query parameters
+    url_clean = url.split('?')[0]
+    # Get last path component
+    filename = os.path.basename(url_clean)
+    if not filename:
+        filename = "download"
+    return filename
+
+
+def calculate_checksum(filepath, algorithm='sha256'):
+    """Calculate checksum of a file."""
+    hash_func = hashlib.new(algorithm)
+    with open(filepath, 'rb') as f:
+        while True:
+            chunk = f.read(DOWNLOAD_CHUNK_SIZE)
+            if not chunk:
+                break
+            hash_func.update(chunk)
+    return hash_func.hexdigest()
+
+
+def download_file(url, dest_path, resume=False):
+    """
+    Download a file from URL to dest_path.
+    Supports resuming interrupted downloads.
+    Returns True on success, False on failure.
+    """
+    dest_path = Path(dest_path)
+    dest_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Check if file already exists
+    if dest_path.exists() and not resume:
+        print(f"  Already exists: {dest_path.name}")
+        return True
+
+    # Get file size for resume support
+    start_pos = 0
+    if resume and dest_path.exists():
+        start_pos = dest_path.stat().st_size
+        print(f"  Resuming from byte {start_pos}")
+
+    # Prepare request
+    req = urllib.request.Request(url)
+    req.add_header('User-Agent', USER_AGENT)
+    if start_pos > 0:
+        req.add_header('Range', f'bytes={start_pos}-')
+
+    try:
+        with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT) as response:
+            total_size = int(response.headers.get('Content-Length', 0))
+            if start_pos > 0:
+                total_size += start_pos
+
+            mode = 'ab' if start_pos > 0 else 'wb'
+            with open(dest_path, mode) as f:
+                while True:
+                    chunk = response.read(DOWNLOAD_CHUNK_SIZE)
+                    if not chunk:
+                        break
+                    f.write(chunk)
+
+                    # Progress indicator
+                    if total_size > 0:
+                        percent = ((start_pos + f.tell() if mode == 'ab' else f.tell()) / total_size) * 100
+                        print(f"\r  Progress: {percent:.1f}%", end='', flush=True)
+
+        print()  # Newline after progress
+        return True
+
+    except urllib.error.HTTPError as e:
+        print(f"\n  HTTP Error {e.code}: {e.reason}", file=sys.stderr)
+        if start_pos > 0 and e.code == 416:
+            # Range not satisfiable - file may be complete
+            print("  Range not satisfiable, checking existing file...")
+            return dest_path.exists()
+        return False
+
+    except urllib.error.URLError as e:
+        print(f"\n  URL Error: {e.reason}", file=sys.stderr)
+        return False
+
+    except Exception as e:
+        print(f"\n  Download error: {e}", file=sys.stderr)
+        return False
+
+
+def verify_checksum(filepath, expected_hash, algorithm='sha256'):
+    """Verify the checksum of a downloaded file."""
+    if not expected_hash or expected_hash.strip() == '':
+        print("  Checksum value not set, skipping verification")
+        return True
+
+    actual_hash = calculate_checksum(filepath, algorithm)
+    if actual_hash.lower() == expected_hash.lower():
+        print(f"  Checksum OK ({algorithm}: {actual_hash[:16]}...)")
+        return True
+    else:
+        print(f"  Checksum MISMATCH!", file=sys.stderr)
+        print(f"    Expected: {expected_hash}", file=sys.stderr)
+        print(f"    Actual:   {actual_hash}", file=sys.stderr)
+        return False
+
+
+def process_package(package_name, categories=None, download_dir=None, env_vars=None, check_only=False):
+    """Process a single package: find source, download, verify."""
+    if download_dir is None:
+        download_dir = DEFAULT_DOWNLOAD_DIR
+
+    if env_vars is None:
+        env_vars = {}
+
+    # Get package info
+    pkg = get_package_info(package_name, categories, env_vars=env_vars)
+    if not pkg:
+        print(f"Error: Package '{package_name}' not found in manifests", file=sys.stderr)
+        return False
+
+    source = pkg.get('source', {})
+    if isinstance(source, str):
+        url = source
+    elif isinstance(source, dict):
+        url = source.get('url', '')
+    else:
+        url = ''
+
+    if not url:
+        print(f"Error: No source URL for package '{package_name}'", file=sys.stderr)
+        return False
+
+    # Get checksum info
+    checksum_info = {}
+    if isinstance(source, dict):
+        cs = source.get('checksum', {})
+        if isinstance(cs, dict):
+            checksum_info = cs
+        else:
+            checksum_info = {}
+
+    checksum_type = checksum_info.get('type', 'sha256')
+    checksum_value = checksum_info.get('value', '')
+
+    # Determine filename
+    filename = get_filename_from_url(url)
+    dest_path = os.path.join(download_dir, filename)
+
+    # Print status
+    version = pkg.get('version', '')
+    version_str = f"-{version}" if version else ""
+    print(f"Downloading {package_name}{version_str}: {filename}")
+
+    if check_only:
+        # Just check if URL is accessible
+        try:
+            req = urllib.request.Request(url)
+            req.add_header('User-Agent', USER_AGENT)
+            with urllib.request.urlopen(req, timeout=10) as response:
+                status = response.status
+                print(f"[OK] {package_name}{version_str} (HTTP {status})")
+                return True
+        except urllib.error.HTTPError as e:
+            print(f"[FAIL] {package_name}{version_str} (HTTP {e.code})")
+            return False
+        except urllib.error.URLError as e:
+            print(f"[FAIL] {package_name}{version_str} ({e.reason})")
+            return False
+
+    # Download if file doesn't exist
+    if not os.path.exists(dest_path):
+        if not download_file(url, dest_path, resume=True):
+            print(f"Error: Failed to download {filename}", file=sys.stderr)
+            return False
+    else:
+        print(f"  Using existing: {filename}")
+
+    # Verify checksum
+    if checksum_value:
+        if not verify_checksum(dest_path, checksum_value, checksum_type):
+            return False
+    else:
+        print("  Checksum not configured, skipping verification")
+
+    print(f"OK: {package_name}{version_str}")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Gozjaro Bootstrap Source Downloader',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument('package', nargs='?', help='Package name to download')
+    parser.add_argument('--download-all', action='store_true',
+                        help='Download all packages in specified categories')
+    parser.add_argument('--check-only', action='store_true',
+                        help='Only check if sources are available')
+    parser.add_argument('--categories', '-c', nargs='*',
+                        help='Categories to process (e.g., base system kernel)')
+    parser.add_argument('--download-dir', '-d', default=DEFAULT_DOWNLOAD_DIR,
+                        help=f'Download directory (default: {DEFAULT_DOWNLOAD_DIR})')
+    parser.add_argument('--manifest-dir', default="config/packages",
+                        help='Manifest directory')
+    parser.add_argument('--env', nargs='*', default=[],
+                        help='Environment variable overrides (e.g., GOZJARO_KERNEL_VERSION=6.12)')
+    parser.add_argument('--no-resume', action='store_true',
+                        help='Do not resume interrupted downloads')
+
+    args = parser.parse_args()
+
+    # Load environment overrides
+    env_vars = {}
+    for item in args.env:
+        if '=' in item:
+            k, v = item.split('=', 1)
+            env_vars[k.strip()] = v.strip()
+
+    categories = args.categories
+    if not categories:
+        categories = ['base', 'system', 'kernel', 'development', 'live']
+
+    download_dir = args.download_dir
+    os.makedirs(download_dir, exist_ok=True)
+
+    if args.package:
+        # Single package mode
+        success = process_package(
+            args.package,
+            categories=categories,
+            download_dir=download_dir,
+            env_vars=env_vars,
+            check_only=args.check_only
+        )
+        sys.exit(0 if success else 1)
+
+    elif args.download_all or args.check_only:
+        # Download/check all packages
+        # First, collect all package names
+        all_packages = []
+        for cat in categories:
+            for ext in ('.yaml', '.yml'):
+                fpath = os.path.join(args.manifest_dir, cat + ext)
+                if os.path.exists(fpath):
+                    data = load_yaml_simple(fpath)
+                    if data:
+                        for pkg in data.get('packages', []):
+                            name = pkg.get('name', '')
+                            if name and name not in all_packages:
+                                all_packages.append(name)
+
+        if not all_packages:
+            print("No packages found in specified categories.")
+            sys.exit(1)
+
+        print(f"Processing {len(all_packages)} packages...")
+        print()
+
+        success_count = 0
+        fail_count = 0
+
+        for pkg_name in sorted(all_packages):
+            if process_package(pkg_name, categories=categories,
+                             download_dir=download_dir, env_vars=env_vars,
+                             check_only=args.check_only):
+                success_count += 1
+            else:
+                fail_count += 1
+
+        print()
+        print(f"Results: {success_count} succeeded, {fail_count} failed")
+        sys.exit(0 if fail_count == 0 else 1)
+
+    else:
+        parser.print_help()
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/manifest-parser.py
+++ b/tools/manifest-parser.py
@@ -1,0 +1,379 @@
+#!/usr/bin/env python3
+"""
+Gozjaro Bootstrap Manifest Parser
+
+Reads YAML package definitions, validates required fields,
+and exports package metadata in JSON format for shell scripts.
+
+Usage:
+    python3 tools/manifest-parser.py <package-name> [categories...]
+    python3 tools/manifest-parser.py --list [categories...]
+    python3 tools/manifest-parser.py --validate [files...]
+    python3 tools/manifest-parser.py --fields <package-name> field1,field2,...
+
+Examples:
+    # Get full JSON for gcc from default categories
+    python3 tools/manifest-parser.py gcc
+
+    # Get specific fields
+    python3 tools/manifest-parser.py gcc url,version
+
+    # List all packages in base category
+    python3 tools/manifest-parser.py --list base
+
+    # Validate manifest files
+    python3 tools/manifest-parser.py --validate config/packages/base.yaml
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def load_yaml_simple(filepath):
+    """
+    Minimal YAML loader that handles the subset of YAML used by Gozjaro manifests.
+    Does not require PyYAML dependency.
+    """
+    try:
+        import yaml
+        with open(filepath, 'r') as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        pass
+
+    # Fallback: manual parsing for simple YAML structures
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    # Try to parse using a simple approach
+    try:
+        return _parse_yaml_fallback(content)
+    except Exception:
+        print(f"Error: Cannot parse {filepath} without PyYAML", file=sys.stderr)
+        print("Install it with: pip install pyyaml", file=sys.stderr)
+        sys.exit(1)
+
+
+def _parse_yaml_fallback(content):
+    """
+    Fallback YAML parser for simple structures.
+    Handles the Gozjaro manifest format without external dependencies.
+    """
+    # Use json module with a pre-processed version
+    lines = content.split('\n')
+    result = {}
+    current_list = None
+    current_item = None
+    current_sub = None
+    indent_stack = []
+
+    for line in lines:
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+    # For robustness, delegate to a structured approach
+    import re
+
+    packages = []
+    current_pkg = {}
+    in_packages = False
+    in_source = False
+    in_checksum = in_patches = in_build = in_configure = in_deps = False
+
+    for line in lines:
+        if line.startswith('packages:'):
+            in_packages = True
+            continue
+
+        if not in_packages:
+            continue
+
+        if line.startswith('  - name:'):
+            if current_pkg:
+                packages.append(current_pkg)
+            current_pkg = {'name': line.split(':', 1)[1].strip().strip('"').strip("'")}
+            in_source = in_checksum = in_patches = in_build = in_configure = in_deps = False
+            continue
+
+        if current_pkg is None:
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        if indent >= 6 and line.strip().startswith('- '):
+            # List item under a key
+            key_part = line.strip()[2:].split(':')[0]
+            if key_part == 'url':
+                current_pkg.setdefault('source', {})['url'] = line.strip()[5:].strip().strip('"').strip("'")
+            elif key_part == 'name':
+                current_pkg.setdefault('patches', []).append({'name': line.strip()[5:].strip().strip('"').strip("'")})
+            elif key_part == 'type':
+                current_pkg.setdefault('checksum', {})['type'] = line.strip()[5:].strip().strip('"').strip("'")
+            elif key_part == 'value':
+                current_pkg.setdefault('checksum', {})['value'] = line.strip()[5:].strip().strip('"').strip("'")
+            continue
+
+        if ':' in line:
+            key, _, value = line.partition(':')
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+
+            if key == 'version':
+                current_pkg['version'] = value
+            elif key == 'category':
+                current_pkg['category'] = value
+            elif key == 'url' and indent == 6:
+                current_pkg.setdefault('source', {})['url'] = value
+            elif key == 'type' and indent == 8:
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['type'] = value
+            elif key == 'value' and indent == 8:
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['value'] = value
+            elif key == 'system' and indent == 6:
+                current_pkg.setdefault('build', {})['system'] = value
+            elif key == 'configure' and indent == 4:
+                current_pkg.setdefault('build', {})['configure'] = []
+                in_configure = True
+            elif key == 'dependencies' and indent == 4:
+                current_pkg['dependencies'] = []
+                in_deps = True
+            elif key == 'patches' and indent == 4:
+                current_pkg['patches'] = []
+                in_patches = True
+
+    if current_pkg:
+        packages.append(current_pkg)
+
+    return {'packages': packages}
+
+
+MANIFEST_DIR = "config/packages"
+REQUIRED_FIELDS = ["name", "version", "source"]
+SOURCE_REQUIRED = ["url"]
+
+
+def find_manifests(manifest_dir):
+    """Find all YAML manifest files in the directory."""
+    manifests = []
+    dir_path = Path(manifest_dir)
+    if dir_path.exists():
+        for f in sorted(dir_path.glob("*.yaml")):
+            manifests.append(str(f))
+        for f in sorted(dir_path.glob("*.yml")):
+            manifests.append(str(f))
+    return manifests
+
+
+def load_all_packages(categories=None, manifest_dir=None):
+    """Load all packages from specified categories (YAML files)."""
+    if manifest_dir is None:
+        manifest_dir = MANIFEST_DIR
+
+    if categories:
+        manifest_files = []
+        for cat in categories:
+            for ext in ('.yaml', '.yml'):
+                fpath = os.path.join(manifest_dir, cat + ext)
+                if os.path.exists(fpath):
+                    manifest_files.append(fpath)
+    else:
+        manifest_files = find_manifests(manifest_dir)
+
+    all_packages = {}
+    all_patches = []
+
+    for mfile in manifest_files:
+        data = load_yaml_simple(mfile)
+        if data is None:
+            continue
+
+        pkg_list = data.get('packages', [])
+        if isinstance(pkg_list, list):
+            for pkg in pkg_list:
+                name = pkg.get('name', '')
+                if name:
+                    all_packages[name] = pkg
+
+        patch_list = data.get('patches', [])
+        if isinstance(patch_list, list):
+            all_patches.extend(patch_list)
+
+    return all_packages, all_patches
+
+
+def validate_package(pkg):
+    """Validate a single package definition. Returns list of errors."""
+    errors = []
+
+    for field in REQUIRED_FIELDS:
+        if field not in pkg:
+            errors.append(f"Missing required field: '{field}'")
+
+    if 'source' in pkg:
+        src = pkg['source']
+        if isinstance(src, dict):
+            for sfield in SOURCE_REQUIRED:
+                if sfield not in src:
+                    errors.append(f"Missing required source field: 'source.{sfield}'")
+
+    return errors
+
+
+def resolve_url(url_template, env_vars=None):
+    """Resolve URL template variables like {{ GOZJARO_KERNEL_VERSION }}."""
+    if env_vars is None:
+        env_vars = {}
+
+    result = url_template
+    import re
+    matches = re.findall(r'\{\{(\w+)\}\}', result)
+    for var in matches:
+        val = env_vars.get(var, '')
+        if val:
+            result = result.replace('{{' + var + '}}', val)
+
+    return result
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Gozjaro Bootstrap Manifest Parser',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument('package', nargs='?', help='Package name to query')
+    parser.add_argument('--list', action='store_true', help='List all package names')
+    parser.add_argument('--validate', nargs='*', metavar='FILE', help='Validate manifest files')
+    parser.add_argument('--fields', help='Comma-separated list of fields to output')
+    parser.add_argument('--categories', nargs='*', default=None,
+                        help='Categories to load (e.g., base system kernel)')
+    parser.add_argument('--manifest-dir', default=MANIFEST_DIR,
+                        help=f'Manifest directory (default: {MANIFEST_DIR})')
+    parser.add_argument('--env', nargs='*', default=[],
+                        help='Environment variable overrides (e.g., GOZJARO_KERNEL_VERSION=6.12)')
+
+    args = parser.parse_args()
+
+    # Handle --validate mode
+    if args.validate:
+        all_valid = True
+        for fpath in args.validate:
+            data = load_yaml_simple(fpath)
+            errors = []
+            if data:
+                for pkg in data.get('packages', []):
+                    errors.extend(validate_package(pkg))
+
+            if errors:
+                all_valid = False
+                print(f"FAIL: {fpath}")
+                for e in errors:
+                    print(f"  - {e}")
+            else:
+                print(f"OK: {fpath}")
+
+        sys.exit(0 if all_valid else 1)
+
+    # Load environment overrides
+    env_vars = {}
+    for item in args.env:
+        if '=' in item:
+            k, v = item.split('=', 1)
+            env_vars[k.strip()] = v.strip()
+
+    # Load packages
+    categories = args.categories
+    if not categories and not args.package and not args.list:
+        categories = ['base', 'system', 'kernel', 'development', 'live']
+
+    all_packages, all_patches = load_all_packages(categories, args.manifest_dir)
+
+    # Handle --list mode
+    if args.list:
+        for name in sorted(all_packages.keys()):
+            print(name)
+        sys.exit(0)
+
+    # Handle specific package query
+    if args.package:
+        pkg = all_packages.get(args.package)
+        if not pkg:
+            print(json.dumps({"error": f"Package '{args.package}' not found"}))
+            sys.exit(1)
+
+        # Validate
+        errors = validate_package(pkg)
+        if errors:
+            print(json.dumps({
+                "error": "Validation failed",
+                "package": args.package,
+                "errors": errors
+            }))
+            sys.exit(1)
+
+        # Build output
+        output = {}
+        output['name'] = pkg['name']
+        output['version'] = pkg.get('version', '')
+        output['category'] = pkg.get('category', '')
+
+        # Source
+        source = pkg.get('source', {})
+        if isinstance(source, dict):
+            url = source.get('url', '')
+            resolved_url = resolve_url(url, env_vars)
+            output['url'] = resolved_url
+            output['raw_url'] = url
+            checksum = source.get('checksum', {})
+            if isinstance(checksum, dict):
+                output['checksum'] = checksum
+            else:
+                output['checksum'] = {}
+        else:
+            output['url'] = str(source)
+            output['checksum'] = {}
+
+        # Patches
+        patches = pkg.get('patches', [])
+        if patches:
+            resolved_patches = []
+            for p in patches:
+                rp = dict(p)
+                if 'url' in rp:
+                    rp['url'] = resolve_url(rp['url'], env_vars)
+                resolved_patches.append(rp)
+            output['patches'] = resolved_patches
+
+        # Build info
+        build = pkg.get('build', {})
+        if build:
+            output['build'] = build
+
+        # Dependencies
+        deps = pkg.get('dependencies', [])
+        if deps:
+            output['dependencies'] = deps
+
+        # Global patches for this package
+        global_patches = [p for p in all_patches if p.get('package') == args.package]
+        if global_patches:
+            output['global_patches'] = global_patches
+
+        print(json.dumps(output, indent=2))
+        sys.exit(0)
+
+    # Default: show summary
+    print(json.dumps({
+        "total_packages": len(all_packages),
+        "total_patches": len(all_patches),
+        "packages": sorted(all_packages.keys()),
+        "patches": [p.get('name', '') for p in all_patches]
+    }, indent=2))
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/source-check.py
+++ b/tools/source-check.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""
+Gozjaro Bootstrap Source Availability Checker
+
+Checks HTTP status of all source URLs in package manifests.
+Detects broken URLs and reports unavailable sources.
+
+Usage:
+    python3 tools/source-check.py [categories...]
+    python3 tools/source-check.py --package <name> [categories...]
+    python3 tools/source-check.py --json [categories...]
+
+Examples:
+    # Check all packages in default categories
+    python3 tools/source-check.py
+
+    # Check only base category
+    python3 tools/source-check.py base
+
+    # Check specific package
+    python3 tools/source-check.py --package gcc
+
+    # Output as JSON for CI integration
+    python3 tools/source-check.py --json
+"""
+
+import argparse
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+from pathlib import Path
+
+
+# Default categories to check
+DEFAULT_CATEGORIES = ['base', 'system', 'kernel', 'development', 'live']
+
+# HTTP timeout for checks (seconds)
+_CHECK_TIMEOUT_DEFAULT = 30
+
+# User agent for requests
+USER_AGENT = "Gozjaro-Bootstrap/1.0"
+
+
+def load_yaml_simple(filepath):
+    """Minimal YAML loader for manifest files."""
+    try:
+        import yaml
+        with open(filepath, 'r') as f:
+            return yaml.safe_load(f)
+    except ImportError:
+        pass
+
+    with open(filepath, 'r') as f:
+        content = f.read()
+
+    packages = []
+    current_pkg = {}
+    in_packages = False
+    in_source = False
+    in_checksum = False
+
+    for line in content.split('\n'):
+        if line.startswith('packages:'):
+            in_packages = True
+            in_source = in_checksum = False
+            continue
+
+        if not in_packages:
+            continue
+
+        # Track indentation level for nested structures
+        stripped = line.strip()
+        if not stripped or stripped.startswith('#'):
+            continue
+
+        indent = len(line) - len(line.lstrip())
+
+        if line.startswith('  - name:'):
+            if current_pkg:
+                packages.append(current_pkg)
+            current_pkg = {'name': line.split(':', 1)[1].strip().strip('"').strip("'")}
+            in_source = in_checksum = False
+            continue
+
+        if current_pkg is None:
+            continue
+
+        if stripped.startswith('- ') and indent >= 6:
+            # List item under a key (like patches)
+            if ':' in stripped[2:]:
+                key = stripped[2:].split(':')[0].strip()
+                if key == 'name':
+                    current_pkg.setdefault('patches', []).append({
+                        'name': stripped[5:].strip().strip('"').strip("'")
+                    })
+            continue
+
+        if ':' in stripped and indent >= 4:
+            key, _, value = stripped.partition(':')
+            key = key.strip()
+            value = value.strip().strip('"').strip("'")
+
+            if key == 'url' and indent == 6:
+                current_pkg.setdefault('source', {})['url'] = value
+                in_source = True
+                in_checksum = False
+            elif key == 'checksum' and indent == 6:
+                current_pkg.setdefault('source', {})['checksum'] = {}
+                in_source = False
+                in_checksum = True
+            elif key == 'type' and (indent == 8 or in_checksum):
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['type'] = value
+            elif key == 'value' and (indent == 8 or in_checksum):
+                current_pkg.setdefault('source', {}).setdefault('checksum', {})['value'] = value
+            elif key == 'name' and not in_source and not in_checksum and indent == 6:
+                # Could be patches section at package level
+                pass
+
+    if current_pkg:
+        packages.append(current_pkg)
+
+    return {'packages': packages}
+
+
+def find_manifests(manifest_dir="config/packages"):
+    """Find all YAML manifest files."""
+    manifests = []
+    dir_path = Path(manifest_dir)
+    if dir_path.exists():
+        for f in sorted(dir_path.glob("*.yaml")):
+            manifests.append(str(f))
+        for f in sorted(dir_path.glob("*.yml")):
+            manifests.append(str(f))
+    return manifests
+
+
+def load_all_packages(categories=None, manifest_dir="config/packages"):
+    """Load all packages from specified categories."""
+    if categories is None:
+        categories = DEFAULT_CATEGORIES
+
+    manifest_files = []
+    for cat in categories:
+        for ext in ('.yaml', '.yml'):
+            fpath = os.path.join(manifest_dir, cat + ext)
+            if os.path.exists(fpath):
+                manifest_files.append(fpath)
+
+    if not manifest_files:
+        manifest_files = find_manifests(manifest_dir)
+
+    all_packages = {}
+
+    for mfile in manifest_files:
+        data = load_yaml_simple(mfile)
+        if data is None:
+            continue
+
+        pkg_list = data.get('packages', [])
+        if isinstance(pkg_list, list):
+            for pkg in pkg_list:
+                name = pkg.get('name', '')
+                if name:
+                    all_packages[name] = pkg
+
+    return all_packages
+
+
+def check_url(url, timeout=_CHECK_TIMEOUT_DEFAULT):
+    """
+    Check if a URL is accessible.
+    Returns: (status_code, error_message)
+    """
+    try:
+        req = urllib.request.Request(url)
+        req.add_header('User-Agent', USER_AGENT)
+
+        # Use HEAD request first, fall back to GET
+        try:
+            opener = urllib.request.build_opener()
+            opener.addheaders = [('User-Agent', USER_AGENT)]
+            with opener.open(url, timeout=timeout) as response:
+                return response.status, None
+        except urllib.error.HTTPError as e:
+            # Some servers don't support HEAD
+            if e.code in (405, 501):
+                # Try GET instead
+                try:
+                    with urllib.request.urlopen(url, timeout=timeout) as response:
+                        return response.status, None
+                except urllib.error.HTTPError as e2:
+                    return e2.code, f"HTTP {e2.code}"
+            return e.code, f"HTTP {e.code}"
+        except urllib.error.URLError as e:
+            return 0, str(e.reason)
+        except TimeoutError:
+            return 0, "Timeout"
+        except Exception as e:
+            return 0, str(e)
+
+    except Exception as e:
+        return 0, str(e)
+
+
+def get_source_url(pkg):
+    """Extract source URL from a package definition."""
+    source = pkg.get('source', {})
+    if isinstance(source, str):
+        return source
+    elif isinstance(source, dict):
+        return source.get('url', '')
+    return ''
+
+
+def check_package(pkg_name, pkg, timeout=None):
+    """Check a single package's source URL."""
+    url = get_source_url(pkg)
+
+    if timeout is None:
+        timeout = _CHECK_TIMEOUT_DEFAULT
+
+    if not url:
+        return {
+            'name': pkg_name,
+            'status': 'SKIP',
+            'message': 'No source URL defined'
+        }
+
+    status_code, error = check_url(url, timeout=timeout)
+
+    if status_code and 200 <= status_code < 400:
+        return {
+            'name': pkg_name,
+            'version': pkg.get('version', ''),
+            'status': 'OK',
+            'http_status': status_code,
+            'url': url
+        }
+    elif status_code == 0:
+        return {
+            'name': pkg_name,
+            'version': pkg.get('version', ''),
+            'status': 'FAIL',
+            'error': error,
+            'url': url
+        }
+    else:
+        return {
+            'name': pkg_name,
+            'version': pkg.get('version', ''),
+            'status': 'ERROR',
+            'http_status': status_code,
+            'url': url
+        }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Gozjaro Bootstrap Source Availability Checker',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__
+    )
+
+    parser.add_argument('--package', '-p', help='Check only specific package')
+    parser.add_argument('--json', action='store_true', dest='output_json',
+                        help='Output results as JSON')
+    parser.add_argument('--categories', '-c', nargs='*',
+                        help='Categories to check (default: all)')
+    parser.add_argument('--manifest-dir', default="config/packages",
+                        help='Manifest directory')
+    parser.add_argument('--timeout', '-t', type=int, default=_CHECK_TIMEOUT_DEFAULT,
+                        help=f'HTTP timeout in seconds (default: {_CHECK_TIMEOUT_DEFAULT})')
+    parser.add_argument('--quiet', '-q', action='store_true',
+                        help='Only show failed checks')
+
+    args = parser.parse_args()
+
+    # Load packages
+    categories = args.categories
+    if not categories:
+        categories = DEFAULT_CATEGORIES
+
+    all_packages = load_all_packages(categories, args.manifest_dir)
+
+    if not all_packages:
+        print("No packages found in specified categories.")
+        sys.exit(0)
+
+    # Filter if specific package requested
+    if args.package:
+        if args.package in all_packages:
+            all_packages = {args.package: all_packages[args.package]}
+        else:
+            print(f"Package '{args.package}' not found.")
+            print(f"Available packages: {', '.join(sorted(load_all_packages(categories, args.manifest_dir).keys()))}")
+            sys.exit(1)
+
+    # Check all packages
+    results = []
+    ok_count = 0
+    fail_count = 0
+    skip_count = 0
+
+    # Store timeout in module scope for check_package to access
+    import __main__
+    __main__.CHECK_TIMEOUT = args.timeout
+
+    for pkg_name in sorted(all_packages.keys()):
+        pkg = all_packages[pkg_name]
+        result = check_package(pkg_name, pkg, timeout=__main__.CHECK_TIMEOUT)
+        results.append(result)
+
+        if result['status'] == 'OK':
+            ok_count += 1
+        elif result['status'] == 'SKIP':
+            skip_count += 1
+        else:
+            fail_count += 1
+
+    # Output results
+    if args.output_json:
+        output = {
+            'total': len(results),
+            'ok': ok_count,
+            'fail': fail_count,
+            'skip': skip_count,
+            'results': results
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        # Text output
+        if not args.quiet:
+            print(f"Checking {len(results)} packages...")
+            print("-" * 60)
+
+        for result in results:
+            if args.quiet and result['status'] == 'OK':
+                continue
+
+            if result['status'] == 'OK':
+                print(f"[OK] {result['name']}-{result.get('version', '')} (HTTP {result.get('http_status', '')})")
+            elif result['status'] == 'SKIP':
+                print(f"[SKIP] {result['name']}: {result.get('message', '')}")
+            elif result['status'] == 'ERROR':
+                print(f"[ERROR] {result['name']}-{result.get('version', '')}: HTTP {result.get('http_status', '')}")
+            else:
+                print(f"[FAIL] {result['name']}-{result.get('version', '')}: {result.get('error', 'Unknown error')}")
+
+        if not args.quiet:
+            print("-" * 60)
+            print(f"Results: {ok_count} OK, {fail_count} FAIL, {skip_count} SKIP")
+
+    # Exit code: non-zero if any failures
+    sys.exit(1 if fail_count > 0 else 0)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Replace hardcoded packages.txt parsing with a dynamic manifest system that reads source URLs from YAML files in config/packages/. Maintain backward compatibility by falling back to legacy text formats when no manifests are found.

- Introduce get_source_urls() to prioritize YAML over legacy configs
- Add download_patches_for_package() helper for structured patch fetching
- Update checksum verification comments to reflect broader algorithm support
- Restructure main download loop for improved readability and logging